### PR TITLE
Fix review findings + v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ enclaude unseal
 enclaude remote add origin git@github.com:you/enclaude-data.git
 enclaude push
 
-# On another device
-enclaude init --import-key     # import your key from file or backup passphrase
-enclaude remote add origin git@github.com:you/enclaude-data.git
-enclaude pull
-enclaude hooks install         # auto-sync on session start/end
+# On another device — clone the encrypted repo and import your key
+git clone git@github.com:you/enclaude-data.git ~/.enclaude
+enclaude key import --from-backup   # or: enclaude key import keyfile.txt
+enclaude unseal
+enclaude hooks install
 ```
 
 ### Auto-Sync with Hooks
@@ -98,7 +98,7 @@ enclaude hooks install         # auto-sync on session start/end
 enclaude hooks install
 ```
 
-This adds `SessionStart` and `SessionEnd` hooks to `~/.claude/settings.json`. When a Claude Code session starts, `enclaude` pulls and unseals the latest data. When it ends, it seals and pushes. Your existing hooks (peon-ping, notchi, etc.) are preserved — the installer appends to the hooks array, never overwrites.
+This adds `SessionStart` and `SessionEnd` hooks to `~/.claude/settings.json`. When a session starts, `enclaude` unseals the latest sealed data. When it ends, it seals changes locally. To enable automatic remote sync, set `auto_push = true` and `auto_pull = true` in `~/.enclaude/seal.toml`. Your existing hooks (peon-ping, notchi, etc.) are preserved — the installer appends to the hooks array, never overwrites.
 
 ## Commands
 
@@ -145,7 +145,8 @@ When pulling from a remote, two devices may have diverged. `enclaude` uses a cus
 | Strategy | Used for | How it works |
 |----------|----------|-------------|
 | `immutable` | Session JSONL files | Union both sides — sessions never change after completion, so there are no conflicts |
-| `jsonl_dedup` | `history.jsonl`, `sessions-index.json` | Parse each line as JSON, SHA-256 hash for dedup, sort by timestamp |
+| `jsonl_dedup` | `history.jsonl` | Parse each line as JSON, SHA-256 hash for dedup, sort by timestamp |
+| `sessions_index` | `sessions-index.json` | Deduplicate entries by `sessionId`, preserving unique sessions from both sides |
 | `last_write_wins` | `settings.json`, `stats-cache.json` | Keep whichever version has the later modification time |
 | `text_merge` | Memory files (`.md`) | Standard 3-way text merge; conflict markers if both sides changed |
 

--- a/cmd/hook_handler.go
+++ b/cmd/hook_handler.go
@@ -132,14 +132,24 @@ func handleSessionEnd() error {
 		logHook("seal error: %v", err)
 		return nil
 	}
+	if stats.Errors > 0 {
+		logHook("seal had %d errors, skipping commit", stats.Errors)
+		return nil
+	}
 
 	// Commit if changes
-	if stats.Added > 0 || stats.Modified > 0 {
+	if stats.HasChanges() {
 		git := gitops.New(sealDir)
-		git.AddAll()
-		msg := fmt.Sprintf("seal: auto-seal from %s (%d new, %d modified)",
-			cfg.Seal.DeviceID, stats.Added, stats.Modified)
-		git.Commit(msg)
+		if err := git.AddAll(); err != nil {
+			logHook("git add warning: %v", err)
+			return nil
+		}
+		msg := fmt.Sprintf("seal: auto-seal from %s (%s)",
+			cfg.Seal.DeviceID, stats)
+		if err := git.Commit(msg); err != nil {
+			logHook("git commit warning: %v", err)
+			return nil
+		}
 
 		// Push if auto-push enabled
 		if cfg.Sync.AutoPush && git.HasRemote("origin") {

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -163,8 +163,12 @@ var keyRotateCmd = &cobra.Command{
 
 		// Commit
 		git := gitops.New(sealDir)
-		git.AddAll()
-		git.Commit(fmt.Sprintf("seal: key rotation from %s", cfg.Seal.DeviceID))
+		if err := git.AddAll(); err != nil {
+			return fmt.Errorf("git add: %w", err)
+		}
+		if err := git.Commit(fmt.Sprintf("seal: key rotation from %s", cfg.Seal.DeviceID)); err != nil {
+			return fmt.Errorf("git commit: %w", err)
+		}
 
 		fmt.Printf("\n%s Key rotated.\n", ui.Green("Done."))
 		fmt.Printf("  Old public key: %s\n", ui.Faint(oldPub))

--- a/cmd/merge_driver.go
+++ b/cmd/merge_driver.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/coredipper/enclaude/internal/config"
@@ -113,10 +114,17 @@ func mergeManifests(ancestorFile, oursFile, theirsFile string) error {
 			continue
 		}
 
-		// Different content — apply merge strategy
-		strategy := merge.Strategy(oursEntry.MergeStrategy)
+		// Different content — resolve merge strategy from config.
+		resolvedStrategy, winningPattern := sealstore.ResolveMergeStrategyWithPattern(path, cfg.Merge)
+		strategy := merge.Strategy(resolvedStrategy)
 		if strategy == "" {
 			strategy = merge.LastWriteWins
+		}
+		// Fail-safe: sessions-index.json is a JSON object, not JSONL.
+		// jsonl_dedup is structurally incompatible and would produce corrupt
+		// data regardless of which config rule resolved it.
+		if strategy == merge.JSONLDedup && filepath.Base(path) == "sessions-index.json" {
+			return fmt.Errorf("refusing to merge %s with jsonl_dedup (sessions-index.json is JSON, not JSONL; rule %q matched). Fix: change the strategy to 'sessions_index' in seal.toml, or run 'enclaude upgrade'", path, winningPattern)
 		}
 
 		// For immutable files, both sides should have the same hash.

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -54,11 +54,18 @@ func runPull(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("seal: %w", err)
 	}
-	if sealStats.Added > 0 || sealStats.Modified > 0 {
-		git.AddAll()
-		msg := fmt.Sprintf("seal: pre-pull seal from %s (%d new, %d modified)",
-			cfg.Seal.DeviceID, sealStats.Added, sealStats.Modified)
-		git.Commit(msg)
+	if sealStats.Errors > 0 {
+		return fmt.Errorf("seal had %d errors — resolve before pulling to avoid data loss", sealStats.Errors)
+	}
+	if sealStats.HasChanges() {
+		if err := git.AddAll(); err != nil {
+			return fmt.Errorf("git add: %w", err)
+		}
+		msg := fmt.Sprintf("seal: pre-pull seal from %s (%s)",
+			cfg.Seal.DeviceID, sealStats)
+		if err := git.Commit(msg); err != nil {
+			return fmt.Errorf("git commit: %w", err)
+		}
 		fmt.Printf("  %s\n", sealStats)
 	} else {
 		fmt.Println("  No local changes.")

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -54,13 +54,20 @@ func runPush(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("seal: %w", err)
 	}
+	if stats.Errors > 0 {
+		return fmt.Errorf("seal had %d errors — resolve before pushing", stats.Errors)
+	}
 	fmt.Printf("  %s\n", stats)
 
-	if stats.Added > 0 || stats.Modified > 0 {
-		git.AddAll()
-		msg := fmt.Sprintf("seal: seal from %s (%d new, %d modified)",
-			cfg.Seal.DeviceID, stats.Added, stats.Modified)
-		git.Commit(msg)
+	if stats.HasChanges() {
+		if err := git.AddAll(); err != nil {
+			return fmt.Errorf("git add: %w", err)
+		}
+		msg := fmt.Sprintf("seal: seal from %s (%s)",
+			cfg.Seal.DeviceID, stats)
+		if err := git.Commit(msg); err != nil {
+			return fmt.Errorf("git commit: %w", err)
+		}
 	}
 
 	// Push

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -69,9 +69,16 @@ func runRollback(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("safety seal: %w", err)
 	}
-	if stats.Added > 0 || stats.Modified > 0 {
-		git.AddAll()
-		git.Commit(fmt.Sprintf("seal: pre-rollback safety seal from %s", cfg.Seal.DeviceID))
+	if stats.Errors > 0 {
+		return fmt.Errorf("safety seal had %d errors — resolve before rolling back", stats.Errors)
+	}
+	if stats.HasChanges() {
+		if err := git.AddAll(); err != nil {
+			return fmt.Errorf("git add: %w", err)
+		}
+		if err := git.Commit(fmt.Sprintf("seal: pre-rollback safety seal from %s", cfg.Seal.DeviceID)); err != nil {
+			return fmt.Errorf("git commit: %w", err)
+		}
 		fmt.Printf("    %s\n", stats)
 	} else {
 		fmt.Println("    No changes to commit.")
@@ -83,10 +90,18 @@ func runRollback(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("git checkout: %w\n%s", err, out)
 	}
 
-	// Step 3: Commit the rollback
+	// Step 3: Commit the rollback (if checkout produced changes)
 	fmt.Println("3/4 Committing rollback...")
-	git.AddAll()
-	git.Commit(fmt.Sprintf("seal: rollback to %s from %s", ref, cfg.Seal.DeviceID))
+	if err := git.AddAll(); err != nil {
+		return fmt.Errorf("git add: %w", err)
+	}
+	if git.HasChanges() {
+		if err := git.Commit(fmt.Sprintf("seal: rollback to %s from %s", ref, cfg.Seal.DeviceID)); err != nil {
+			return fmt.Errorf("git commit: %w", err)
+		}
+	} else {
+		fmt.Println("    Already at requested state.")
+	}
 
 	// Step 4: Unseal
 	fmt.Println("4/4 Unsealing restored state...")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const Version = "0.1.0"
+var Version = "0.2.0"
 
 var (
 	flagVerbose  bool

--- a/cmd/seal.go
+++ b/cmd/seal.go
@@ -34,16 +34,34 @@ func runSeal(cmd *cobra.Command, args []string) error {
 		cfg.Seal.ClaudeDir = flagClaudeDir
 	}
 
+	if flagDryRun {
+		fmt.Println("(dry run — showing what would be sealed)")
+		diff, err := store.Status(cfg)
+		if err != nil {
+			return fmt.Errorf("status: %w", err)
+		}
+		if len(diff.Added) == 0 && len(diff.Modified) == 0 && len(diff.Deleted) == 0 {
+			fmt.Println("  No changes to seal.")
+		} else {
+			for _, p := range diff.Added {
+				fmt.Printf("  [new] %s\n", p)
+			}
+			for _, p := range diff.Modified {
+				fmt.Printf("  [mod] %s\n", p)
+			}
+			for _, p := range diff.Deleted {
+				fmt.Printf("  [del] %s\n", p)
+			}
+		}
+		return nil
+	}
+
 	recipient, source, err := crypto.LoadPublicKey()
 	if err != nil {
 		return fmt.Errorf("loading key: %w", err)
 	}
 	if flagVerbose {
 		fmt.Printf("Using key from %s\n", source)
-	}
-
-	if flagDryRun {
-		fmt.Println("(dry run — no changes will be made)")
 	}
 
 	fmt.Println("Sealing...")
@@ -53,19 +71,20 @@ func runSeal(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("  %s\n", stats)
 
-	if flagDryRun {
-		return nil
+	if stats.Errors > 0 {
+		fmt.Printf("  Warning: %d errors encountered. Skipping commit.\n", stats.Errors)
+		return fmt.Errorf("seal had %d errors", stats.Errors)
 	}
 
 	// Commit if there are changes
-	if stats.Added > 0 || stats.Modified > 0 {
+	if stats.HasChanges() {
 		gitAdd := exec.Command("git", "-C", sealDir, "add", ".")
 		if err := gitAdd.Run(); err != nil {
 			return fmt.Errorf("git add: %w", err)
 		}
 
-		msg := fmt.Sprintf("seal: seal from %s (%d new, %d modified)",
-			cfg.Seal.DeviceID, stats.Added, stats.Modified)
+		msg := fmt.Sprintf("seal: seal from %s (%s)",
+			cfg.Seal.DeviceID, stats)
 		gitCommit := exec.Command("git", "-C", sealDir, "commit", "-m", msg)
 		if flagVerbose {
 			gitCommit.Stdout = cmd.OutOrStdout()
@@ -77,10 +96,6 @@ func runSeal(cmd *cobra.Command, args []string) error {
 		fmt.Println("  Committed to seal store.")
 	} else {
 		fmt.Println("  No changes to commit.")
-	}
-
-	if stats.Errors > 0 {
-		fmt.Printf("  Warning: %d errors encountered.\n", stats.Errors)
 	}
 
 	return nil

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -55,13 +55,20 @@ func runSync(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("seal: %w", err)
 	}
+	if sealStats.Errors > 0 {
+		return fmt.Errorf("seal had %d errors — resolve before syncing to avoid data loss", sealStats.Errors)
+	}
 	fmt.Printf("    %s\n", sealStats)
 
-	if sealStats.Added > 0 || sealStats.Modified > 0 {
-		git.AddAll()
-		msg := fmt.Sprintf("seal: seal from %s (%d new, %d modified)",
-			cfg.Seal.DeviceID, sealStats.Added, sealStats.Modified)
-		git.Commit(msg)
+	if sealStats.HasChanges() {
+		if err := git.AddAll(); err != nil {
+			return fmt.Errorf("git add: %w", err)
+		}
+		msg := fmt.Sprintf("seal: seal from %s (%s)",
+			cfg.Seal.DeviceID, sealStats)
+		if err := git.Commit(msg); err != nil {
+			return fmt.Errorf("git commit: %w", err)
+		}
 	}
 
 	// 2. Pull

--- a/cmd/unseal.go
+++ b/cmd/unseal.go
@@ -32,16 +32,34 @@ func runUnseal(cmd *cobra.Command, args []string) error {
 		cfg.Seal.ClaudeDir = flagClaudeDir
 	}
 
+	if flagDryRun {
+		fmt.Println("(dry run — showing what would change)")
+		diff, err := store.UnsealStatus(cfg)
+		if err != nil {
+			return fmt.Errorf("unseal status: %w", err)
+		}
+		if len(diff.Added) == 0 && len(diff.Modified) == 0 && len(diff.Deleted) == 0 {
+			fmt.Println("  No changes needed.")
+		} else {
+			for _, p := range diff.Added {
+				fmt.Printf("  [restore] %s\n", p)
+			}
+			for _, p := range diff.Modified {
+				fmt.Printf("  [update] %s\n", p)
+			}
+			for _, p := range diff.Deleted {
+				fmt.Printf("  [delete] %s\n", p)
+			}
+		}
+		return nil
+	}
+
 	identity, source, err := crypto.LoadKey()
 	if err != nil {
 		return fmt.Errorf("loading key: %w", err)
 	}
 	if flagVerbose {
 		fmt.Printf("Using key from %s\n", source)
-	}
-
-	if flagDryRun {
-		fmt.Println("(dry run — showing what would be restored)")
 	}
 
 	fmt.Println("Unsealing...")

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/coredipper/enclaude/internal/config"
+	"github.com/coredipper/enclaude/internal/store"
+	"github.com/coredipper/enclaude/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var upgradeCmd = &cobra.Command{
+	Use:   "upgrade",
+	Short: "Upgrade seal.toml to the latest config version",
+	Long:  "Applies one-time migrations to seal.toml and bumps the config version.",
+	RunE:  runUpgrade,
+}
+
+func init() {
+	rootCmd.AddCommand(upgradeCmd)
+}
+
+func runUpgrade(cmd *cobra.Command, args []string) error {
+	sealDir := getSealDir()
+
+	cfg, err := config.Load(sealDir)
+	if err != nil {
+		return err
+	}
+
+	changed := false
+
+	// v0/v1 -> v2: fix sessions-index.json merge strategy
+	if cfg.Version < 2 {
+		if cfg.Merge["projects/*/sessions-index.json"] == "jsonl_dedup" {
+			cfg.Merge["projects/*/sessions-index.json"] = "sessions_index"
+			fmt.Println("  Fixed: projects/*/sessions-index.json strategy: jsonl_dedup -> sessions_index")
+			changed = true
+		}
+	}
+
+	// Validate: check if sessions-index.json still effectively resolves to
+	// jsonl_dedup after migration. Uses the same precedence logic as the
+	// merge driver. Best-effort probe set — the merge driver catches any
+	// edge cases that slip through at runtime.
+	probes := []string{
+		"projects/a/sessions-index.json",
+		"projects/A/sessions-index.json",
+		"projects/ABC/sessions-index.json",
+		"projects/abc/sessions-index.json",
+		"projects/0/sessions-index.json",
+		"projects/00/sessions-index.json",
+		"projects/123/sessions-index.json",
+		"projects/my-project/sessions-index.json",
+		"projects/proj-abc123/sessions-index.json",
+		"projects/customer-42/sessions-index.json",
+		"projects/ABCD/sessions-index.json",
+		"projects/test/sessions-index.json",
+	}
+	for _, testPath := range probes {
+		resolvedStrategy, winningPattern := store.ResolveMergeStrategyWithPattern(testPath, cfg.Merge)
+		if resolvedStrategy == "jsonl_dedup" {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"\n%s %s resolves to jsonl_dedup (via rule %q).\n"+
+					"  Update it to 'sessions_index' in seal.toml.\n", ui.Red("Warning:"), testPath, winningPattern)
+			return fmt.Errorf("manual fix required: update rule %q to 'sessions_index' in seal.toml", winningPattern)
+		}
+	}
+
+	if cfg.Version >= config.ConfigVersion && !changed {
+		fmt.Printf("Config is already at version %d. No issues found.\n", cfg.Version)
+		return nil
+	}
+
+	cfg.Version = config.ConfigVersion
+	if err := cfg.Save(sealDir); err != nil {
+		return fmt.Errorf("saving config: %w", err)
+	}
+
+	if changed {
+		fmt.Printf("\n%s Config upgraded to version %d.\n", ui.Green("Done."), config.ConfigVersion)
+	} else {
+		fmt.Printf("\n%s Config version bumped to %d (no strategy changes needed).\n", ui.Green("Done."), config.ConfigVersion)
+	}
+	return nil
+}
+
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,7 +9,12 @@ import (
 	"github.com/pelletier/go-toml/v2"
 )
 
+// ConfigVersion tracks the config schema version for one-time migrations.
+// Bump this when adding migrations in Load().
+const ConfigVersion = 2
+
 type Config struct {
+	Version  int            `toml:"config_version"`
 	Seal    SealSection    `toml:"seal"`
 	Sync     SyncSection     `toml:"sync"`
 	Include  PatternSection  `toml:"include"`
@@ -36,6 +41,7 @@ type PatternSection struct {
 
 func DefaultConfig(claudeDir, sealDir string) *Config {
 	return &Config{
+		Version: ConfigVersion,
 		Seal: SealSection{
 			ClaudeDir: claudeDir,
 			SealDir:  sealDir,
@@ -86,7 +92,7 @@ func DefaultConfig(claudeDir, sealDir string) *Config {
 		},
 		Merge: map[string]string{
 			"history.jsonl":                    "jsonl_dedup",
-			"projects/*/sessions-index.json":   "jsonl_dedup",
+			"projects/*/sessions-index.json":   "sessions_index",
 			"stats-cache.json":                 "last_write_wins",
 			"settings.json":                    "last_write_wins",
 			"projects/*/*.jsonl":               "immutable",
@@ -108,6 +114,18 @@ func Load(sealDir string) (*Config, error) {
 	var cfg Config
 	if err := toml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parsing seal.toml: %w", err)
+	}
+
+	// Overlay default merge strategies for keys not present in the loaded config.
+	defaults := DefaultConfig("", "")
+	if cfg.Merge == nil {
+		cfg.Merge = defaults.Merge
+	} else {
+		for pattern, strategy := range defaults.Merge {
+			if _, exists := cfg.Merge[pattern]; !exists {
+				cfg.Merge[pattern] = strategy
+			}
+		}
 	}
 
 	return &cfg, nil

--- a/internal/merge/jsonl.go
+++ b/internal/merge/jsonl.go
@@ -90,10 +90,19 @@ func MergeSessionsIndex(ours, theirs []byte) ([]byte, error) {
 		merged = append(merged, seen[sid])
 	}
 
-	// Build output — try to preserve the original structure
-	var outObj map[string]json.RawMessage
-	if err := json.Unmarshal(ours, &outObj); err != nil {
-		outObj = make(map[string]json.RawMessage)
+	// Build output — merge top-level keys from both sides.
+	// Start with theirs, then overlay ours so ours takes precedence
+	// for shared keys. This preserves metadata from theirs that ours lacks.
+	var theirsObj, oursObj map[string]json.RawMessage
+	json.Unmarshal(theirs, &theirsObj)
+	json.Unmarshal(ours, &oursObj)
+
+	outObj := make(map[string]json.RawMessage)
+	for k, v := range theirsObj {
+		outObj[k] = v
+	}
+	for k, v := range oursObj {
+		outObj[k] = v
 	}
 
 	entriesJSON, err := json.Marshal(merged)

--- a/internal/merge/strategies.go
+++ b/internal/merge/strategies.go
@@ -9,10 +9,11 @@ import (
 type Strategy string
 
 const (
-	Immutable    Strategy = "immutable"
-	JSONLDedup   Strategy = "jsonl_dedup"
+	Immutable     Strategy = "immutable"
+	JSONLDedup    Strategy = "jsonl_dedup"
+	SessionsIndex Strategy = "sessions_index"
 	LastWriteWins Strategy = "last_write_wins"
-	TextMerge    Strategy = "text_merge"
+	TextMerge     Strategy = "text_merge"
 )
 
 // FileMeta carries metadata needed for merge decisions.
@@ -29,6 +30,8 @@ func Merge(strategy Strategy, ancestor, ours, theirs []byte, oursMeta, theirsMet
 		return mergeImmutable(ours, theirs)
 	case JSONLDedup:
 		return MergeJSONL(ours, theirs)
+	case SessionsIndex:
+		return MergeSessionsIndex(ours, theirs)
 	case LastWriteWins:
 		return mergeLastWriteWins(ours, theirs, oursMeta, theirsMeta)
 	case TextMerge:

--- a/internal/store/repair_test.go
+++ b/internal/store/repair_test.go
@@ -76,13 +76,12 @@ func TestVerifyDetectsMissingObject(t *testing.T) {
 
 	Seal(cfg, identity.Recipient(), false, nil)
 
-	// Delete one object
+	// Delete the object for history.jsonl specifically (has unique content,
+	// unlike abc123.jsonl and agent-abc.jsonl which share the same hash).
 	manifest, _ := LoadManifest(sealDir)
 	store := NewObjectStore(sealDir)
-	for _, entry := range manifest.Files {
-		os.Remove(store.ObjectPath(entry.ContentHash))
-		break // delete just one
-	}
+	entry := manifest.Files["history.jsonl"]
+	os.Remove(store.ObjectPath(entry.ContentHash))
 
 	result, err := Verify(cfg, identity, false)
 	if err != nil {
@@ -127,15 +126,11 @@ func TestRepairFixesMissing(t *testing.T) {
 
 	Seal(cfg, identity.Recipient(), false, nil)
 
-	// Delete one object
+	// Delete the object for history.jsonl (has unique content).
 	manifest, _ := LoadManifest(sealDir)
 	store := NewObjectStore(sealDir)
-	var deletedPath string
-	for path, entry := range manifest.Files {
-		os.Remove(store.ObjectPath(entry.ContentHash))
-		deletedPath = path
-		break
-	}
+	deletedPath := "history.jsonl"
+	os.Remove(store.ObjectPath(manifest.Files[deletedPath].ContentHash))
 
 	// Repair should re-seal from plaintext
 	result, err := Repair(cfg, identity, false, false)
@@ -152,6 +147,54 @@ func TestRepairFixesMissing(t *testing.T) {
 	entry := manifest2.Files[deletedPath]
 	if !store.Exists(entry.ContentHash) {
 		t.Error("object still missing after repair")
+	}
+}
+
+func TestRepairUpdatesManifestWhenPlaintextChanged(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+
+	Seal(cfg, identity.Recipient(), false, nil)
+
+	// Delete the object for history.jsonl (has unique content, unlike
+	// abc123.jsonl and agent-abc.jsonl which share the same hash).
+	manifest, _ := LoadManifest(sealDir)
+	store := NewObjectStore(sealDir)
+	deletedPath := "history.jsonl"
+	oldHash := manifest.Files[deletedPath].ContentHash
+	os.Remove(store.ObjectPath(oldHash))
+
+	// Modify the plaintext so its hash will differ from manifest
+	newContent := []byte("completely new content after modification")
+	os.WriteFile(filepath.Join(claudeDir, deletedPath), newContent, 0644)
+	expectedHash := ContentHash(newContent)
+
+	// Repair should re-seal from modified plaintext and update manifest
+	result, err := Repair(cfg, identity, false, false)
+	if err != nil {
+		t.Fatalf("Repair() error: %v", err)
+	}
+
+	if result.Fixed != 1 {
+		t.Errorf("expected 1 fixed, got %d", result.Fixed)
+	}
+
+	// Manifest should now point to the new hash, not the old one
+	manifest2, _ := LoadManifest(sealDir)
+	entry := manifest2.Files[deletedPath]
+	if entry.ContentHash == oldHash {
+		t.Error("manifest still points to old hash after repair")
+	}
+	if entry.ContentHash != expectedHash {
+		t.Errorf("manifest hash = %s, want %s", entry.ContentHash[:16], expectedHash[:16])
+	}
+
+	// New object should exist
+	if !store.Exists(expectedHash) {
+		t.Error("new object missing after repair")
 	}
 }
 

--- a/internal/store/scanner.go
+++ b/internal/store/scanner.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,10 +23,20 @@ type ScanResult struct {
 // include patterns but not matching exclude patterns.
 func ScanFiles(claudeDir string, includes, excludes []string) ([]ScanResult, error) {
 	var results []ScanResult
+	var walkErrors int
 
 	err := filepath.Walk(claudeDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return nil // skip inaccessible files
+			// Count errors for paths that could contain managed files.
+			// For directories: any non-excluded dir could have included
+			// descendants. For files: check include/exclude directly.
+			if rel, relErr := filepath.Rel(claudeDir, path); relErr == nil && rel != "." {
+				excluded := matchesAny(rel, excludes) || matchesAny(rel+"/", excludes)
+				if !excluded {
+					walkErrors++
+				}
+			}
+			return nil // continue scanning other files
 		}
 		if info.IsDir() {
 			rel, _ := filepath.Rel(claudeDir, path)
@@ -63,23 +74,29 @@ func ScanFiles(claudeDir string, includes, excludes []string) ([]ScanResult, err
 		return nil
 	})
 
-	return results, err
+	if err != nil {
+		return results, err
+	}
+	if walkErrors > 0 {
+		return results, fmt.Errorf("scan incomplete: %d inaccessible file(s)", walkErrors)
+	}
+	return results, nil
 }
 
 // matchesAny checks if a relative path matches any of the glob patterns.
 // Supports ** for recursive directory matching.
 func matchesAny(relPath string, patterns []string) bool {
 	for _, pattern := range patterns {
-		if matchGlob(relPath, pattern) {
+		if MatchGlob(relPath, pattern) {
 			return true
 		}
 	}
 	return false
 }
 
-// matchGlob matches a path against a glob pattern with ** support.
+// MatchGlob matches a path against a glob pattern with ** support.
 // It splits both path and pattern into segments and matches segment-by-segment.
-func matchGlob(path, pattern string) bool {
+func MatchGlob(path, pattern string) bool {
 	if !strings.Contains(pattern, "**") {
 		matched, _ := filepath.Match(pattern, path)
 		return matched

--- a/internal/store/scanner_test.go
+++ b/internal/store/scanner_test.go
@@ -140,9 +140,9 @@ func TestMatchGlob(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.path+"_"+tt.pattern, func(t *testing.T) {
-			got := matchGlob(tt.path, tt.pattern)
+			got := MatchGlob(tt.path, tt.pattern)
 			if got != tt.want {
-				t.Errorf("matchGlob(%q, %q) = %v, want %v", tt.path, tt.pattern, got, tt.want)
+				t.Errorf("MatchGlob(%q, %q) = %v, want %v", tt.path, tt.pattern, got, tt.want)
 			}
 		})
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,11 +18,21 @@ type SealStats struct {
 	Scanned   int
 	Added     int
 	Modified  int
+	Deleted   int
 	Unchanged int
 	Errors    int
 }
 
+// HasChanges returns true if the seal produced any modifications worth committing.
+func (s SealStats) HasChanges() bool {
+	return s.Added > 0 || s.Modified > 0 || s.Deleted > 0
+}
+
 func (s SealStats) String() string {
+	if s.Deleted > 0 {
+		return fmt.Sprintf("scanned %d files: %d new, %d modified, %d deleted, %d unchanged",
+			s.Scanned, s.Added, s.Modified, s.Deleted, s.Unchanged)
+	}
 	return fmt.Sprintf("scanned %d files: %d new, %d modified, %d unchanged",
 		s.Scanned, s.Added, s.Modified, s.Unchanged)
 }
@@ -32,10 +42,15 @@ type UnsealStats struct {
 	Total     int
 	Restored  int
 	Unchanged int
+	Deleted   int
 	Errors    int
 }
 
 func (s UnsealStats) String() string {
+	if s.Deleted > 0 {
+		return fmt.Sprintf("%d files: %d restored, %d unchanged, %d deleted",
+			s.Total, s.Restored, s.Unchanged, s.Deleted)
+	}
 	return fmt.Sprintf("%d files: %d restored, %d unchanged",
 		s.Total, s.Restored, s.Unchanged)
 }
@@ -140,7 +155,7 @@ func Seal(cfg *config.Config, recipient age.Recipient, verbose bool, progress Pr
 			SizePlaintext:  f.Size,
 			SizeEncrypted:  int64(len(encrypted)),
 			Mtime:          time.UnixMilli(f.ModTimeMs).UTC().Format(time.RFC3339),
-			MergeStrategy:  resolveMergeStrategy(f.RelPath, cfg.Merge),
+			MergeStrategy:  ResolveMergeStrategy(f.RelPath, cfg.Merge),
 			JSONLLineCount: lineCount,
 			SessionComplete: isSessionComplete(f.RelPath),
 		}
@@ -153,6 +168,7 @@ func Seal(cfg *config.Config, recipient age.Recipient, verbose bool, progress Pr
 				fmt.Printf("  [del] %s\n", path)
 			}
 			delete(manifest.Files, path)
+			stats.Deleted++
 		}
 	}
 
@@ -164,7 +180,8 @@ func Seal(cfg *config.Config, recipient age.Recipient, verbose bool, progress Pr
 	return stats, nil
 }
 
-// Unseal decrypts seal contents back to claudeDir.
+// Unseal decrypts seal contents back to claudeDir and removes managed
+// files not in the manifest. The manifest is the source of truth.
 func Unseal(cfg *config.Config, identity age.Identity, verbose bool, progress ProgressFunc) (UnsealStats, error) {
 	var stats UnsealStats
 	sealDir := cfg.Seal.SealDir
@@ -234,8 +251,50 @@ func Unseal(cfg *config.Config, identity age.Identity, verbose bool, progress Pr
 		stats.Restored++
 	}
 
+	// Delete managed files not in the manifest. The manifest is the source
+	// of truth — after git pull/merge, it reflects the intended state
+	// including remote deletions. Skip if restore had errors (incomplete
+	// unseal should not trigger deletions).
+	if stats.Errors > 0 {
+		return stats, nil
+	}
+	existingFiles, scanErr := ScanFiles(cfg.Seal.ClaudeDir, cfg.Include.Patterns, cfg.Exclude.Patterns)
+	if scanErr != nil {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "  warning: skipping deletion (scan incomplete: %v)\n", scanErr)
+		}
+		stats.Errors++
+		return stats, nil
+	}
+	{
+		manifestPaths := make(map[string]bool, len(manifest.Files))
+		for relPath := range manifest.Files {
+			manifestPaths[relPath] = true
+		}
+		for _, f := range existingFiles {
+			if !manifestPaths[f.RelPath] {
+				if err := os.Remove(f.AbsPath); err == nil {
+					stats.Deleted++
+					if verbose {
+						fmt.Printf("  [delete] %s\n", f.RelPath)
+					}
+					dir := filepath.Dir(f.AbsPath)
+					if dir != cfg.Seal.ClaudeDir {
+						os.Remove(dir)
+					}
+				} else {
+					stats.Errors++
+					if verbose {
+						fmt.Fprintf(os.Stderr, "  warning: cannot delete %s: %v\n", f.RelPath, err)
+					}
+				}
+			}
+		}
+	}
+
 	return stats, nil
 }
+
 
 // Status returns the diff between the current claude directory and the seal manifest.
 func Status(cfg *config.Config) (*DiffResult, error) {
@@ -265,23 +324,132 @@ func Status(cfg *config.Config) (*DiffResult, error) {
 	return &diff, nil
 }
 
-// resolveMergeStrategy finds the merge strategy for a file based on glob patterns.
-func resolveMergeStrategy(relPath string, strategies map[string]string) string {
-	// Try exact match first
-	if s, ok := strategies[relPath]; ok {
-		return s
+// UnsealStatus returns what Unseal would do without actually writing anything.
+// "Added" = files in manifest but missing on disk (would be restored).
+// "Modified" = files on disk with different content than manifest (would be overwritten).
+// "Deleted" = managed files on disk but not in manifest (would be deleted).
+func UnsealStatus(cfg *config.Config) (*DiffResult, error) {
+	manifest, err := LoadManifest(cfg.Seal.SealDir)
+	if err != nil {
+		return nil, fmt.Errorf("loading manifest: %w", err)
 	}
-	// Try glob patterns
-	for pattern, strategy := range strategies {
-		if matchGlob(relPath, pattern) {
-			return strategy
+	if manifest == nil {
+		return nil, fmt.Errorf("no manifest found — is the seal store initialized?")
+	}
+
+	// Scan existing files. If claudeDir doesn't exist yet (first-time
+	// restore), treat as empty — all manifest files would be restored.
+	var files []ScanResult
+	if _, statErr := os.Stat(cfg.Seal.ClaudeDir); statErr == nil {
+		files, err = ScanFiles(cfg.Seal.ClaudeDir, cfg.Include.Patterns, cfg.Exclude.Patterns)
+		if err != nil {
+			return nil, fmt.Errorf("scanning files: %w", err)
 		}
 	}
+
+	// Build current state from disk
+	onDisk := make(map[string]string) // relPath -> hash
+	for _, f := range files {
+		data, err := os.ReadFile(f.AbsPath)
+		if err != nil {
+			continue
+		}
+		onDisk[f.RelPath] = ContentHash(data)
+	}
+
+	var result DiffResult
+
+	// Files in manifest: would be restored or overwritten
+	for relPath, entry := range manifest.Files {
+		diskHash, exists := onDisk[relPath]
+		if !exists {
+			result.Added = append(result.Added, relPath) // missing on disk, would restore
+		} else if diskHash != entry.ContentHash {
+			result.Modified = append(result.Modified, relPath) // different, would overwrite
+		}
+	}
+
+	// Managed files on disk but not in manifest: would be deleted
+	for relPath := range onDisk {
+		if _, inManifest := manifest.Files[relPath]; !inManifest {
+			result.Deleted = append(result.Deleted, relPath)
+		}
+	}
+
+	return &result, nil
+}
+
+// ResolveMergeStrategy finds the merge strategy for a file based on glob patterns.
+func ResolveMergeStrategy(relPath string, strategies map[string]string) string {
+	strategy, _ := ResolveMergeStrategyWithPattern(relPath, strategies)
+	return strategy
+}
+
+// ResolveMergeStrategyWithPattern returns both the strategy and the pattern that matched.
+// An empty pattern means a built-in default was used.
+// When multiple glob patterns match, the most specific wins (most segments,
+// fewest wildcards). This ensures deterministic resolution regardless of
+// Go map iteration order.
+func ResolveMergeStrategyWithPattern(relPath string, strategies map[string]string) (strategy string, pattern string) {
+	// Try exact match first (highest priority)
+	if s, ok := strategies[relPath]; ok {
+		return s, relPath
+	}
+
+	// Collect all matching glob patterns, pick the most specific
+	bestPattern := ""
+	bestStrategy := ""
+	bestScore := ""
+
+	for p, s := range strategies {
+		if p == relPath {
+			continue // already checked exact match
+		}
+		if MatchGlob(relPath, p) {
+			score := patternSpecificity(p)
+			if score > bestScore {
+				bestScore = score
+				bestPattern = p
+				bestStrategy = s
+			}
+		}
+	}
+
+	if bestPattern != "" {
+		return bestStrategy, bestPattern
+	}
+
 	// Default
 	if strings.HasSuffix(relPath, ".md") {
-		return "text_merge"
+		return "text_merge", ""
 	}
-	return "last_write_wins"
+	return "last_write_wins", ""
+}
+
+// patternSpecificity returns a comparable score slice for a glob pattern.
+// Compared lexicographically, more specific patterns sort higher.
+// Per-segment scoring: literal=3, constrained glob (contains [)=2, *=1, **=0.
+// Ties broken by segment count (more = more specific) then pattern string.
+func patternSpecificity(pattern string) string {
+	segs := strings.Split(pattern, "/")
+	// Sum per-segment scores: literal=3, glob=2, *=1, **=0.
+	// Higher total = more specific.
+	total := 0
+	for _, seg := range segs {
+		switch {
+		case seg == "**":
+			total += 0
+		case seg == "*":
+			total += 1
+		case strings.ContainsAny(seg, "*?["):
+			total += 2
+		default:
+			total += 3
+		}
+	}
+	// Fixed-width: total score (2 digits), segment count (2 digits), pattern.
+	// Higher total wins; ties broken by more segments, then lexical.
+	return fmt.Sprintf("%02d:%02d:%s", total, len(segs), pattern)
 }
 
 // isSessionComplete determines if a session JSONL file is likely complete.
@@ -379,7 +547,17 @@ func Repair(cfg *config.Config, identity age.Identity, deleteOrphans bool, verbo
 		return nil, err
 	}
 
+	manifest, err := LoadManifest(cfg.Seal.SealDir)
+	if err != nil {
+		return nil, fmt.Errorf("loading manifest: %w", err)
+	}
+
 	store := NewObjectStore(cfg.Seal.SealDir)
+
+	// Track old hashes that get superseded during repair so we can
+	// include them in orphan deletion (they become orphaned only after
+	// the manifest is updated with new hashes).
+	var superseded []string
 
 	// Try to fix missing/corrupt by re-sealing from plaintext
 	for _, path := range append(result.MissingObjects, result.CorruptObjects...) {
@@ -397,15 +575,63 @@ func Repair(cfg *config.Config, identity age.Identity, deleteOrphans bool, verbo
 		if err := store.Write(hash, encrypted); err != nil {
 			continue
 		}
+
+		// Track superseded hash before updating manifest
+		oldHash := manifest.Files[path].ContentHash
+		if oldHash != hash && oldHash != "" {
+			superseded = append(superseded, oldHash)
+		}
+
+		// Rebuild full manifest entry from repaired state
+		entry := manifest.Files[path]
+		entry.ContentHash = hash
+		entry.SizePlaintext = int64(len(plaintext))
+		entry.SizeEncrypted = int64(len(encrypted))
+		entry.MergeStrategy = ResolveMergeStrategy(path, cfg.Merge)
+		// Update Mtime from current file stat (important for last_write_wins)
+		if info, err := os.Stat(absPath); err == nil {
+			entry.Mtime = info.ModTime().UTC().Format(time.RFC3339)
+		}
+		// Recompute JSONL line count
+		if strings.HasSuffix(path, ".jsonl") {
+			entry.JSONLLineCount = bytes.Count(plaintext, []byte("\n"))
+			if len(plaintext) > 0 && plaintext[len(plaintext)-1] != '\n' {
+				entry.JSONLLineCount++
+			}
+		}
+		entry.SessionComplete = isSessionComplete(path)
+		manifest.Files[path] = entry
+
 		result.Fixed++
 		if verbose {
 			fmt.Printf("  [fixed] %s (re-sealed from plaintext)\n", path)
 		}
 	}
 
-	// Delete orphans if requested
+	// Save updated manifest before deleting any objects — if save fails,
+	// the old manifest still has valid references to existing objects.
+	if result.Fixed > 0 {
+		if err := manifest.Save(cfg.Seal.SealDir); err != nil {
+			return result, fmt.Errorf("saving manifest: %w", err)
+		}
+	}
+
+	// Delete orphans only after manifest is safely persisted
 	if deleteOrphans {
-		for _, hash := range result.OrphanObjects {
+		// Build set of hashes still referenced by the updated manifest
+		// so we don't delete objects that another entry still needs
+		// (e.g., two files with identical content share one object).
+		referenced := make(map[string]bool)
+		for _, entry := range manifest.Files {
+			referenced[entry.ContentHash] = true
+		}
+
+		// Include superseded hashes (old objects replaced during repair)
+		allOrphans := append(result.OrphanObjects, superseded...)
+		for _, hash := range allOrphans {
+			if referenced[hash] {
+				continue // still needed by another manifest entry
+			}
 			store.Delete(hash)
 			if verbose {
 				fmt.Printf("  [deleted] orphan %s\n", hash[:16])

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -161,6 +161,68 @@ func TestSealIncrementalDetectsChanges(t *testing.T) {
 	}
 }
 
+func TestUnsealDeletesRemovedFiles(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+
+	// Seal all files
+	Seal(cfg, identity.Recipient(), false, nil)
+
+	// Remove one file from the manifest (simulate another device deleting it)
+	manifest, _ := LoadManifest(sealDir)
+	var removedPath string
+	for path := range manifest.Files {
+		removedPath = path
+		delete(manifest.Files, path)
+		break
+	}
+	manifest.Save(sealDir)
+
+	// Unseal should delete the stale file
+	stats, err := Unseal(cfg, identity, false, nil)
+	if err != nil {
+		t.Fatalf("Unseal() error: %v", err)
+	}
+
+	if stats.Deleted != 1 {
+		t.Errorf("expected 1 deleted, got %d", stats.Deleted)
+	}
+
+	// Verify the file is gone
+	absPath := filepath.Join(claudeDir, removedPath)
+	if _, err := os.Stat(absPath); !os.IsNotExist(err) {
+		t.Errorf("file %s should have been deleted but still exists", removedPath)
+	}
+}
+
+func TestUnsealDoesNotDeleteUnmanagedFiles(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+
+	// Add a file that doesn't match include patterns (unmanaged)
+	unmanagedPath := filepath.Join(claudeDir, "custom-script.sh")
+	os.WriteFile(unmanagedPath, []byte("#!/bin/bash\necho hi"), 0755)
+
+	// Seal (won't include custom-script.sh)
+	Seal(cfg, identity.Recipient(), false, nil)
+
+	// Unseal should NOT delete the unmanaged file
+	_, err := Unseal(cfg, identity, false, nil)
+	if err != nil {
+		t.Fatalf("Unseal() error: %v", err)
+	}
+
+	if _, err := os.Stat(unmanagedPath); os.IsNotExist(err) {
+		t.Error("unmanaged file was deleted — Unseal should only delete managed files")
+	}
+}
+
 func TestManifestDiff(t *testing.T) {
 	old := &Manifest{
 		Files: map[string]FileEntry{


### PR DESCRIPTION
## Summary
- Fix 7 code review findings: unseal deletion propagation, dry-run safety, git error handling, repair correctness, sessions-index merge strategy, version ldflags, README sync
- Add `enclaude upgrade` command for config migration with version tracking
- Add merge driver safety: reject structurally incompatible jsonl_dedup for sessions-index.json
- Deterministic merge-strategy resolution with specificity scoring
- Robust scan error handling: inaccessible managed paths abort operations instead of causing silent data loss
- Bump version to 0.2.0

## Test plan
- [x] `go test ./... -count=1` — 55 tests pass (3 new + 1 flake fix)
- [x] `go vet ./...` — clean
- [x] `go build -ldflags "-X ...Version=test"` — version override works
- [x] Store tests run 5x with no flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)