### PR TITLE
Fix hook detection: absolute paths, shell quoting, and legacy migration

### DIFF
--- a/internal/gitops/hooks.go
+++ b/internal/gitops/hooks.go
@@ -282,34 +282,27 @@ func shellSplitFirst(cmd string) (token, rest string) {
 		return "", ""
 	}
 
-	// Unquoted token
-	if cmd[0] != '\'' && cmd[0] != '"' {
-		if i := strings.IndexByte(cmd, ' '); i >= 0 {
-			return cmd[:i], cmd[i:]
-		}
-		return cmd, ""
-	}
-
-	// Quoted token — accumulate segments handling '\'' escapes
+	// Accumulate token segments: quoted runs, '\'' escapes, and
+	// adjacent unquoted characters are all part of one POSIX token
+	// until we hit unquoted whitespace.
 	var b strings.Builder
 	i := 0
 	for i < len(cmd) {
-		if cmd[i] == '\'' {
-			// Find closing single quote
+		switch cmd[i] {
+		case '\'':
 			end := strings.IndexByte(cmd[i+1:], '\'')
 			if end < 0 {
-				// Unterminated quote — take the rest
 				b.WriteString(cmd[i+1:])
 				return b.String(), ""
 			}
 			b.WriteString(cmd[i+1 : i+1+end])
-			i = i + 1 + end + 1 // past closing quote
-			// Check for '\'' continuation (escaped single quote)
+			i = i + 1 + end + 1
+			// Handle '\'' escape (end quote, escaped quote, reopen)
 			if strings.HasPrefix(cmd[i:], `\'`) {
 				b.WriteByte('\'')
-				i += 2 // skip \'
+				i += 2
 			}
-		} else if cmd[i] == '"' {
+		case '"':
 			end := strings.IndexByte(cmd[i+1:], '"')
 			if end < 0 {
 				b.WriteString(cmd[i+1:])
@@ -317,9 +310,12 @@ func shellSplitFirst(cmd string) (token, rest string) {
 			}
 			b.WriteString(cmd[i+1 : i+1+end])
 			i = i + 1 + end + 1
-		} else {
-			break
+		case ' ', '\t':
+			return b.String(), cmd[i:]
+		default:
+			b.WriteByte(cmd[i])
+			i++
 		}
 	}
-	return b.String(), cmd[i:]
+	return b.String(), ""
 }

--- a/internal/gitops/hooks.go
+++ b/internal/gitops/hooks.go
@@ -269,5 +269,12 @@ func hasSealHook(hooks map[string]json.RawMessage, event string) bool {
 }
 
 func containsMarker(cmd string) bool {
-	return strings.Contains(cmd, hookMarker)
+	// New-style: marker comment (written by current version)
+	if strings.Contains(cmd, hookMarker) {
+		return true
+	}
+	// Legacy: hooks installed before the marker was introduced.
+	// Checks for "enclaude" and "hook-handler" as separate substrings
+	// to handle both bare and shell-quoted path forms.
+	return strings.Contains(cmd, "enclaude") && strings.Contains(cmd, "hook-handler")
 }

--- a/internal/gitops/hooks.go
+++ b/internal/gitops/hooks.go
@@ -284,7 +284,11 @@ func isLegacyHook(cmd string) bool {
 	if i < 0 {
 		return false
 	}
-	// Verify "enclaude" is the full binary name, not a prefix like "enclaude-wrapper"
+	// Boundary before: must be start of string, path separator, or quote
+	if i > 0 && cmd[i-1] != '/' && cmd[i-1] != '\'' && cmd[i-1] != '"' {
+		return false
+	}
+	// Boundary after: must be end of string, space, or quote
 	end := i + len(name)
 	if end < len(cmd) && cmd[end] != ' ' && cmd[end] != '\'' && cmd[end] != '"' {
 		return false

--- a/internal/gitops/hooks.go
+++ b/internal/gitops/hooks.go
@@ -300,7 +300,11 @@ func extractAction(cmd string) string {
 // marker format. Returns the number of hooks migrated.
 func migrateLegacyHooks(hooks map[string]json.RawMessage) int {
 	migrated := 0
-	for event, raw := range hooks {
+	for _, event := range []string{"SessionStart", "SessionEnd"} {
+		raw, ok := hooks[event]
+		if !ok {
+			continue
+		}
 		var entries []hookEntry
 		if err := json.Unmarshal(raw, &entries); err != nil {
 			continue

--- a/internal/gitops/hooks.go
+++ b/internal/gitops/hooks.go
@@ -8,25 +8,29 @@ import (
 	"strings"
 )
 
-const sealHookMarker = "enclaude hook-handler"
-
 // resolveExecutable returns the absolute path to the currently running binary.
 // Package-level var so tests can override it.
 var resolveExecutable = os.Executable
 
-// sealHookCommand returns the absolute path to the enclaude binary
+// sealHookCommand returns the shell-safe absolute path to the enclaude binary
 // for use in hook commands. Hooks run via /bin/sh which may not have
 // ~/go/bin or other user-specific paths in PATH.
+// We intentionally do NOT resolve symlinks: symlinks (e.g. from Homebrew)
+// are stable across upgrades, while their targets are versioned and ephemeral.
 func sealHookCommand() string {
 	exe, err := resolveExecutable()
 	if err != nil {
 		return "enclaude hook-handler"
 	}
-	resolved, err := filepath.EvalSymlinks(exe)
-	if err != nil {
-		return exe + " hook-handler"
-	}
-	return resolved + " hook-handler"
+	return shellQuote(exe) + " hook-handler"
+}
+
+// shellQuote wraps a string in single quotes for safe use in /bin/sh commands.
+// Single quotes prevent all shell expansion. Any literal single quotes in the
+// input are handled by ending the quoted segment, inserting an escaped quote,
+// and reopening.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // hookEntry matches Claude Code's hook config structure.
@@ -257,5 +261,7 @@ func hasSealHook(hooks map[string]json.RawMessage, event string) bool {
 }
 
 func containsMarker(cmd string) bool {
-	return strings.Contains(cmd, sealHookMarker)
+	// Match both bare ("enclaude hook-handler ...") and shell-quoted
+	// ("'/path/to/enclaude' hook-handler ...") forms.
+	return strings.Contains(cmd, "enclaude") && strings.Contains(cmd, "hook-handler")
 }

--- a/internal/gitops/hooks.go
+++ b/internal/gitops/hooks.go
@@ -310,7 +310,7 @@ func shellSplitFirst(cmd string) (token, rest string) {
 			}
 			b.WriteString(cmd[i+1 : i+1+end])
 			i = i + 1 + end + 1
-		case ' ', '\t':
+		case ' ', '\t', '\n':
 			return b.String(), cmd[i:]
 		default:
 			b.WriteByte(cmd[i])

--- a/internal/gitops/hooks.go
+++ b/internal/gitops/hooks.go
@@ -262,6 +262,13 @@ func hasSealHook(hooks map[string]json.RawMessage, event string) bool {
 
 func containsMarker(cmd string) bool {
 	// Match both bare ("enclaude hook-handler ...") and shell-quoted
-	// ("'/path/to/enclaude' hook-handler ...") forms.
-	return strings.Contains(cmd, "enclaude") && strings.Contains(cmd, "hook-handler")
+	// ("'/path/to/enclaude' hook-handler ...") forms by verifying
+	// argv[0] is "enclaude" or ends with "/enclaude" (possibly quoted)
+	// and argv[1] is "hook-handler".
+	fields := strings.Fields(cmd)
+	if len(fields) < 2 || fields[1] != "hook-handler" {
+		return false
+	}
+	arg0 := strings.Trim(fields[0], "'\"")
+	return arg0 == "enclaude" || strings.HasSuffix(arg0, "/enclaude")
 }

--- a/internal/gitops/hooks.go
+++ b/internal/gitops/hooks.go
@@ -271,11 +271,18 @@ func hasMarker(cmd string) bool {
 	return strings.Contains(cmd, hookMarker)
 }
 
-// isLegacyHook detects pre-marker enclaude hooks by checking for both
-// "enclaude" and "hook-handler" as substrings. Intentionally loose —
-// used only by migration and removal, never for idempotency checks.
+// isLegacyHook detects pre-marker enclaude hooks. Requires "enclaude"
+// followed by "hook-handler" in the command, matching all legacy forms:
+// bare ("enclaude hook-handler ..."), absolute path
+// ("/path/to/enclaude hook-handler ..."), and quoted
+// ("'/path/to/enclaude' hook-handler ...").
+// Used only by migration and removal, never for idempotency checks.
 func isLegacyHook(cmd string) bool {
-	return strings.Contains(cmd, "enclaude") && strings.Contains(cmd, "hook-handler")
+	i := strings.Index(cmd, "enclaude")
+	if i < 0 {
+		return false
+	}
+	return strings.Contains(cmd[i:], "hook-handler")
 }
 
 // extractAction extracts the hook action (e.g. "session-start") from a

--- a/internal/gitops/hooks.go
+++ b/internal/gitops/hooks.go
@@ -271,18 +271,25 @@ func hasMarker(cmd string) bool {
 	return strings.Contains(cmd, hookMarker)
 }
 
-// isLegacyHook detects pre-marker enclaude hooks. Requires "enclaude"
-// followed by "hook-handler" in the command, matching all legacy forms:
+// isLegacyHook detects pre-marker enclaude hooks. Requires the exact
+// binary name "enclaude" (not "enclaude-wrapper" etc.) followed by
+// "hook-handler" in the command. Matches all legacy forms:
 // bare ("enclaude hook-handler ..."), absolute path
 // ("/path/to/enclaude hook-handler ..."), and quoted
 // ("'/path/to/enclaude' hook-handler ...").
 // Used only by migration and removal, never for idempotency checks.
 func isLegacyHook(cmd string) bool {
-	i := strings.Index(cmd, "enclaude")
+	const name = "enclaude"
+	i := strings.Index(cmd, name)
 	if i < 0 {
 		return false
 	}
-	return strings.Contains(cmd[i:], "hook-handler")
+	// Verify "enclaude" is the full binary name, not a prefix like "enclaude-wrapper"
+	end := i + len(name)
+	if end < len(cmd) && cmd[end] != ' ' && cmd[end] != '\'' && cmd[end] != '"' {
+		return false
+	}
+	return strings.Contains(cmd[end:], "hook-handler")
 }
 
 // extractAction extracts the hook action (e.g. "session-start") from a

--- a/internal/gitops/hooks.go
+++ b/internal/gitops/hooks.go
@@ -8,6 +8,11 @@ import (
 	"strings"
 )
 
+// hookMarker is a shell comment appended to every enclaude hook command.
+// Detection uses a simple strings.Contains on this marker, avoiding
+// any need to parse shell quoting or tokenization.
+const hookMarker = "# enclaude-managed"
+
 // resolveExecutable returns the absolute path to the currently running binary.
 // Package-level var so tests can override it.
 var resolveExecutable = os.Executable
@@ -23,6 +28,11 @@ func sealHookCommand() string {
 		return "enclaude hook-handler"
 	}
 	return shellQuote(exe) + " hook-handler"
+}
+
+// sealHookFull builds a complete hook command with the marker comment.
+func sealHookFull(action string) string {
+	return sealHookCommand() + " " + action + "  " + hookMarker
 }
 
 // shellQuote wraps a string in single quotes for safe use in /bin/sh commands.
@@ -71,13 +81,11 @@ func InstallHooks(claudeDir string) error {
 		hooks = make(map[string]json.RawMessage)
 	}
 
-	hookCmd := sealHookCommand()
-
 	// Add SessionStart hook
 	if err := addHookEntry(hooks, "SessionStart", hookEntry{
 		Hooks: []hookDef{{
 			Type:    "command",
-			Command: hookCmd + " session-start",
+			Command: sealHookFull("session-start"),
 			Timeout: 30,
 		}},
 	}); err != nil {
@@ -88,7 +96,7 @@ func InstallHooks(claudeDir string) error {
 	if err := addHookEntry(hooks, "SessionEnd", hookEntry{
 		Hooks: []hookDef{{
 			Type:    "command",
-			Command: hookCmd + " session-end",
+			Command: sealHookFull("session-end"),
 			Timeout: 60,
 			Async:   true,
 		}},
@@ -261,61 +269,5 @@ func hasSealHook(hooks map[string]json.RawMessage, event string) bool {
 }
 
 func containsMarker(cmd string) bool {
-	// Match both bare ("enclaude hook-handler ...") and shell-quoted
-	// ("'/path with spaces/enclaude' hook-handler ...") forms.
-	// Handles the '\'' escape sequence used by shellQuote for paths
-	// containing apostrophes.
-	arg0, rest := shellSplitFirst(cmd)
-	if arg0 != "enclaude" && !strings.HasSuffix(arg0, "/enclaude") {
-		return false
-	}
-	arg1, _ := shellSplitFirst(rest)
-	return arg1 == "hook-handler"
-}
-
-// shellSplitFirst extracts the first shell token from cmd, handling
-// single-quoted strings including the '\'' escape idiom. Returns the
-// unquoted token value and the remaining string.
-func shellSplitFirst(cmd string) (token, rest string) {
-	cmd = strings.TrimSpace(cmd)
-	if len(cmd) == 0 {
-		return "", ""
-	}
-
-	// Accumulate token segments: quoted runs, '\'' escapes, and
-	// adjacent unquoted characters are all part of one POSIX token
-	// until we hit unquoted whitespace.
-	var b strings.Builder
-	i := 0
-	for i < len(cmd) {
-		switch cmd[i] {
-		case '\'':
-			end := strings.IndexByte(cmd[i+1:], '\'')
-			if end < 0 {
-				b.WriteString(cmd[i+1:])
-				return b.String(), ""
-			}
-			b.WriteString(cmd[i+1 : i+1+end])
-			i = i + 1 + end + 1
-			// Handle '\'' escape (end quote, escaped quote, reopen)
-			if strings.HasPrefix(cmd[i:], `\'`) {
-				b.WriteByte('\'')
-				i += 2
-			}
-		case '"':
-			end := strings.IndexByte(cmd[i+1:], '"')
-			if end < 0 {
-				b.WriteString(cmd[i+1:])
-				return b.String(), ""
-			}
-			b.WriteString(cmd[i+1 : i+1+end])
-			i = i + 1 + end + 1
-		case ' ', '\t', '\n':
-			return b.String(), cmd[i:]
-		default:
-			b.WriteByte(cmd[i])
-			i++
-		}
-	}
-	return b.String(), ""
+	return strings.Contains(cmd, hookMarker)
 }

--- a/internal/gitops/hooks.go
+++ b/internal/gitops/hooks.go
@@ -262,13 +262,36 @@ func hasSealHook(hooks map[string]json.RawMessage, event string) bool {
 
 func containsMarker(cmd string) bool {
 	// Match both bare ("enclaude hook-handler ...") and shell-quoted
-	// ("'/path/to/enclaude' hook-handler ...") forms by verifying
-	// argv[0] is "enclaude" or ends with "/enclaude" (possibly quoted)
-	// and argv[1] is "hook-handler".
-	fields := strings.Fields(cmd)
-	if len(fields) < 2 || fields[1] != "hook-handler" {
+	// ("'/path with spaces/enclaude' hook-handler ...") forms.
+	// We extract argv[0] respecting quotes, then check the remainder
+	// starts with "hook-handler".
+	arg0, rest := splitShellArg0(cmd)
+	arg0 = strings.Trim(arg0, "'\"")
+	if arg0 != "enclaude" && !strings.HasSuffix(arg0, "/enclaude") {
 		return false
 	}
-	arg0 := strings.Trim(fields[0], "'\"")
-	return arg0 == "enclaude" || strings.HasSuffix(arg0, "/enclaude")
+	rest = strings.TrimSpace(rest)
+	return strings.HasPrefix(rest, "hook-handler")
+}
+
+// splitShellArg0 splits a command string into its first argument and
+// the remainder, respecting single and double quotes around arg0.
+func splitShellArg0(cmd string) (arg0, rest string) {
+	cmd = strings.TrimSpace(cmd)
+	if len(cmd) == 0 {
+		return "", ""
+	}
+	if cmd[0] == '\'' || cmd[0] == '"' {
+		quote := cmd[0]
+		end := strings.IndexByte(cmd[1:], quote)
+		if end >= 0 {
+			// include the quotes in arg0 so caller can strip them
+			return cmd[:end+2], cmd[end+2:]
+		}
+	}
+	// unquoted: split on first space
+	if i := strings.IndexByte(cmd, ' '); i >= 0 {
+		return cmd[:i], cmd[i:]
+	}
+	return cmd, ""
 }

--- a/internal/gitops/hooks.go
+++ b/internal/gitops/hooks.go
@@ -263,35 +263,63 @@ func hasSealHook(hooks map[string]json.RawMessage, event string) bool {
 func containsMarker(cmd string) bool {
 	// Match both bare ("enclaude hook-handler ...") and shell-quoted
 	// ("'/path with spaces/enclaude' hook-handler ...") forms.
-	// We extract argv[0] respecting quotes, then check the remainder
-	// starts with "hook-handler".
-	arg0, rest := splitShellArg0(cmd)
-	arg0 = strings.Trim(arg0, "'\"")
+	// Handles the '\'' escape sequence used by shellQuote for paths
+	// containing apostrophes.
+	arg0, rest := shellSplitFirst(cmd)
 	if arg0 != "enclaude" && !strings.HasSuffix(arg0, "/enclaude") {
 		return false
 	}
-	rest = strings.TrimSpace(rest)
-	return strings.HasPrefix(rest, "hook-handler")
+	arg1, _ := shellSplitFirst(rest)
+	return arg1 == "hook-handler"
 }
 
-// splitShellArg0 splits a command string into its first argument and
-// the remainder, respecting single and double quotes around arg0.
-func splitShellArg0(cmd string) (arg0, rest string) {
+// shellSplitFirst extracts the first shell token from cmd, handling
+// single-quoted strings including the '\'' escape idiom. Returns the
+// unquoted token value and the remaining string.
+func shellSplitFirst(cmd string) (token, rest string) {
 	cmd = strings.TrimSpace(cmd)
 	if len(cmd) == 0 {
 		return "", ""
 	}
-	if cmd[0] == '\'' || cmd[0] == '"' {
-		quote := cmd[0]
-		end := strings.IndexByte(cmd[1:], quote)
-		if end >= 0 {
-			// include the quotes in arg0 so caller can strip them
-			return cmd[:end+2], cmd[end+2:]
+
+	// Unquoted token
+	if cmd[0] != '\'' && cmd[0] != '"' {
+		if i := strings.IndexByte(cmd, ' '); i >= 0 {
+			return cmd[:i], cmd[i:]
+		}
+		return cmd, ""
+	}
+
+	// Quoted token — accumulate segments handling '\'' escapes
+	var b strings.Builder
+	i := 0
+	for i < len(cmd) {
+		if cmd[i] == '\'' {
+			// Find closing single quote
+			end := strings.IndexByte(cmd[i+1:], '\'')
+			if end < 0 {
+				// Unterminated quote — take the rest
+				b.WriteString(cmd[i+1:])
+				return b.String(), ""
+			}
+			b.WriteString(cmd[i+1 : i+1+end])
+			i = i + 1 + end + 1 // past closing quote
+			// Check for '\'' continuation (escaped single quote)
+			if strings.HasPrefix(cmd[i:], `\'`) {
+				b.WriteByte('\'')
+				i += 2 // skip \'
+			}
+		} else if cmd[i] == '"' {
+			end := strings.IndexByte(cmd[i+1:], '"')
+			if end < 0 {
+				b.WriteString(cmd[i+1:])
+				return b.String(), ""
+			}
+			b.WriteString(cmd[i+1 : i+1+end])
+			i = i + 1 + end + 1
+		} else {
+			break
 		}
 	}
-	// unquoted: split on first space
-	if i := strings.IndexByte(cmd, ' '); i >= 0 {
-		return cmd[:i], cmd[i:]
-	}
-	return cmd, ""
+	return b.String(), cmd[i:]
 }

--- a/internal/gitops/hooks.go
+++ b/internal/gitops/hooks.go
@@ -81,6 +81,9 @@ func InstallHooks(claudeDir string) error {
 		hooks = make(map[string]json.RawMessage)
 	}
 
+	// Upgrade any pre-marker hooks to current format
+	migrateLegacyHooks(hooks)
+
 	// Add SessionStart hook
 	if err := addHookEntry(hooks, "SessionStart", hookEntry{
 		Hooks: []hookDef{{
@@ -193,10 +196,11 @@ func addHookEntry(hooks map[string]json.RawMessage, event string, entry hookEntr
 		}
 	}
 
-	// Check if seal hook already exists
+	// Check if seal hook already exists (marker-only — legacy hooks
+	// are migrated before addHookEntry is called)
 	for _, e := range entries {
 		for _, h := range e.Hooks {
-			if containsMarker(h.Command) {
+			if hasMarker(h.Command) {
 				return nil // already installed
 			}
 		}
@@ -226,27 +230,20 @@ func removeHookEntries(hooks map[string]json.RawMessage, event string) {
 
 	var filtered []hookEntry
 	for _, e := range entries {
-		isSeal := false
+		isOurs := false
 		for _, h := range e.Hooks {
-			if containsMarker(h.Command) {
-				isSeal = true
+			if hasMarker(h.Command) || isLegacyHook(h.Command) {
+				isOurs = true
 				break
 			}
 		}
-		if !isSeal {
+		if !isOurs {
 			filtered = append(filtered, e)
 		}
 	}
 
-	if len(filtered) == 0 {
-		// Don't leave empty arrays; remove the key entirely
-		// Actually, keep it as empty array to preserve the key
-		data, _ := json.Marshal(filtered)
-		hooks[event] = data
-	} else {
-		data, _ := json.Marshal(filtered)
-		hooks[event] = data
-	}
+	data, _ := json.Marshal(filtered)
+	hooks[event] = data
 }
 
 func hasSealHook(hooks map[string]json.RawMessage, event string) bool {
@@ -260,7 +257,7 @@ func hasSealHook(hooks map[string]json.RawMessage, event string) bool {
 	}
 	for _, e := range entries {
 		for _, h := range e.Hooks {
-			if containsMarker(h.Command) {
+			if hasMarker(h.Command) {
 				return true
 			}
 		}
@@ -268,13 +265,74 @@ func hasSealHook(hooks map[string]json.RawMessage, event string) bool {
 	return false
 }
 
-func containsMarker(cmd string) bool {
-	// New-style: marker comment (written by current version)
-	if strings.Contains(cmd, hookMarker) {
-		return true
-	}
-	// Legacy: hooks installed before the marker was introduced.
-	// Checks for "enclaude" and "hook-handler" as separate substrings
-	// to handle both bare and shell-quoted path forms.
+// hasMarker checks whether a command carries the enclaude marker comment.
+// This is the sole detection mechanism for current-format hooks.
+func hasMarker(cmd string) bool {
+	return strings.Contains(cmd, hookMarker)
+}
+
+// isLegacyHook detects pre-marker enclaude hooks by checking for both
+// "enclaude" and "hook-handler" as substrings. Intentionally loose —
+// used only by migration and removal, never for idempotency checks.
+func isLegacyHook(cmd string) bool {
 	return strings.Contains(cmd, "enclaude") && strings.Contains(cmd, "hook-handler")
+}
+
+// extractAction extracts the hook action (e.g. "session-start") from a
+// legacy hook command. Finds "hook-handler" and returns the next token.
+func extractAction(cmd string) string {
+	const sentinel = "hook-handler"
+	idx := strings.Index(cmd, sentinel)
+	if idx < 0 {
+		return ""
+	}
+	rest := strings.TrimSpace(cmd[idx+len(sentinel):])
+	if rest == "" {
+		return ""
+	}
+	if i := strings.IndexByte(rest, ' '); i >= 0 {
+		return rest[:i]
+	}
+	return rest
+}
+
+// migrateLegacyHooks upgrades pre-marker hook commands to the current
+// marker format. Returns the number of hooks migrated.
+func migrateLegacyHooks(hooks map[string]json.RawMessage) int {
+	migrated := 0
+	for event, raw := range hooks {
+		var entries []hookEntry
+		if err := json.Unmarshal(raw, &entries); err != nil {
+			continue
+		}
+
+		changed := false
+		for i := range entries {
+			for j := range entries[i].Hooks {
+				h := &entries[i].Hooks[j]
+				if hasMarker(h.Command) {
+					continue
+				}
+				if !isLegacyHook(h.Command) {
+					continue
+				}
+				action := extractAction(h.Command)
+				if action == "" {
+					continue
+				}
+				h.Command = sealHookFull(action)
+				changed = true
+				migrated++
+			}
+		}
+
+		if changed {
+			data, err := json.Marshal(entries)
+			if err != nil {
+				continue
+			}
+			hooks[event] = data
+		}
+	}
+	return migrated
 }

--- a/internal/gitops/hooks.go
+++ b/internal/gitops/hooks.go
@@ -5,10 +5,29 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
-const sealHookCommand = "enclaude hook-handler"
 const sealHookMarker = "enclaude hook-handler"
+
+// resolveExecutable returns the absolute path to the currently running binary.
+// Package-level var so tests can override it.
+var resolveExecutable = os.Executable
+
+// sealHookCommand returns the absolute path to the enclaude binary
+// for use in hook commands. Hooks run via /bin/sh which may not have
+// ~/go/bin or other user-specific paths in PATH.
+func sealHookCommand() string {
+	exe, err := resolveExecutable()
+	if err != nil {
+		return "enclaude hook-handler"
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return exe + " hook-handler"
+	}
+	return resolved + " hook-handler"
+}
 
 // hookEntry matches Claude Code's hook config structure.
 type hookEntry struct {
@@ -48,12 +67,13 @@ func InstallHooks(claudeDir string) error {
 		hooks = make(map[string]json.RawMessage)
 	}
 
+	hookCmd := sealHookCommand()
+
 	// Add SessionStart hook
 	if err := addHookEntry(hooks, "SessionStart", hookEntry{
-		Matcher: "",
 		Hooks: []hookDef{{
 			Type:    "command",
-			Command: sealHookCommand + " session-start",
+			Command: hookCmd + " session-start",
 			Timeout: 30,
 		}},
 	}); err != nil {
@@ -62,10 +82,9 @@ func InstallHooks(claudeDir string) error {
 
 	// Add SessionEnd hook (async to avoid blocking Claude shutdown)
 	if err := addHookEntry(hooks, "SessionEnd", hookEntry{
-		Matcher: "",
 		Hooks: []hookDef{{
 			Type:    "command",
-			Command: sealHookCommand + " session-end",
+			Command: hookCmd + " session-end",
 			Timeout: 60,
 			Async:   true,
 		}},
@@ -238,5 +257,5 @@ func hasSealHook(hooks map[string]json.RawMessage, event string) bool {
 }
 
 func containsMarker(cmd string) bool {
-	return len(cmd) >= len(sealHookMarker) && cmd[:len(sealHookMarker)] == sealHookMarker
+	return strings.Contains(cmd, sealHookMarker)
 }

--- a/internal/gitops/hooks_test.go
+++ b/internal/gitops/hooks_test.go
@@ -192,6 +192,31 @@ func TestSymlinkNotResolved(t *testing.T) {
 	}
 }
 
+func TestContainsMarker(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want bool
+	}{
+		// Should match
+		{"enclaude hook-handler session-start", true},
+		{"'/usr/local/bin/enclaude' hook-handler session-end", true},
+		{"/Users/bogdan/go/bin/enclaude hook-handler session-start", true},
+		{`"/opt/homebrew/bin/enclaude" hook-handler session-end`, true},
+		// Should NOT match
+		{"some-script --enclaude --hook-handler", false},
+		{"/path/to/hook-handler enclaude", false},
+		{"enclaude-wrapper hook-handler session-start", false},
+		{"/path/to/not-enclaude hook-handler session-start", false},
+		{"peon.sh", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := containsMarker(tt.cmd); got != tt.want {
+			t.Errorf("containsMarker(%q) = %v, want %v", tt.cmd, got, tt.want)
+		}
+	}
+}
+
 func TestHooksInstalledFalseWhenMissing(t *testing.T) {
 	dir := t.TempDir()
 	if HooksInstalled(dir) {

--- a/internal/gitops/hooks_test.go
+++ b/internal/gitops/hooks_test.go
@@ -196,15 +196,17 @@ func TestContainsMarker(t *testing.T) {
 		cmd  string
 		want bool
 	}{
-		// Should match — any command containing the marker comment
+		// New-style: marker comment present
 		{"enclaude hook-handler session-start  " + hookMarker, true},
 		{"'/usr/local/bin/enclaude' hook-handler session-end  " + hookMarker, true},
 		{"'/path with spaces/enclaude' hook-handler session-start  " + hookMarker, true},
-		// Should NOT match — no marker comment
-		{"enclaude hook-handler session-start", false},
-		{"'/usr/local/bin/enclaude' hook-handler session-end", false},
-		{"some-script --enclaude --hook-handler", false},
+		// Legacy: no marker but contains "enclaude hook-handler"
+		{"enclaude hook-handler session-start", true},
+		{"'/usr/local/bin/enclaude' hook-handler session-end", true},
+		{"/Users/bogdan/go/bin/enclaude hook-handler session-start", true},
+		// Should NOT match
 		{"/path/to/peon-ping/peon.sh", false},
+		{"some-random-script --foo", false},
 		{"", false},
 	}
 	for _, tt := range tests {

--- a/internal/gitops/hooks_test.go
+++ b/internal/gitops/hooks_test.go
@@ -203,12 +203,14 @@ func TestContainsMarker(t *testing.T) {
 		{"/Users/bogdan/go/bin/enclaude hook-handler session-start", true},
 		{`"/opt/homebrew/bin/enclaude" hook-handler session-end`, true},
 		{"'/path with spaces/enclaude' hook-handler session-start", true},
-		{"'/it'\\''s here/enclaude' hook-handler session-end", false}, // malformed after split, acceptable
+		{"'/it'\\''s here/enclaude' hook-handler session-end", true}, // escaped apostrophe via '\''
 		// Should NOT match
 		{"some-script --enclaude --hook-handler", false},
 		{"/path/to/hook-handler enclaude", false},
 		{"enclaude-wrapper hook-handler session-start", false},
 		{"/path/to/not-enclaude hook-handler session-start", false},
+		{"enclaude hook-handler-wrapper session-start", false},
+		{"'/path/enclaude' hook-handler2", false},
 		{"peon.sh", false},
 		{"", false},
 	}

--- a/internal/gitops/hooks_test.go
+++ b/internal/gitops/hooks_test.go
@@ -279,9 +279,12 @@ func TestIsLegacyHook(t *testing.T) {
 		{"enclaude hook-handler session-start", true},
 		{"/usr/local/bin/enclaude hook-handler session-end", true},
 		{"'/path/to/enclaude' hook-handler session-start", true},
-		// Not legacy
+		// Not legacy — prefix/suffix mismatch
 		{"enclaude-wrapper hook-handler session-start", false},
 		{"/usr/local/bin/enclaude-proxy hook-handler session-end", false},
+		{"myenclaude hook-handler session-start", false},
+		{"/opt/bin/notenclaude hook-handler session-end", false},
+		// Not legacy — unrelated
 		{"/path/to/peon-ping/peon.sh", false},
 		{"some-random-script --foo", false},
 		{"", false},

--- a/internal/gitops/hooks_test.go
+++ b/internal/gitops/hooks_test.go
@@ -202,6 +202,8 @@ func TestContainsMarker(t *testing.T) {
 		{"'/usr/local/bin/enclaude' hook-handler session-end", true},
 		{"/Users/bogdan/go/bin/enclaude hook-handler session-start", true},
 		{`"/opt/homebrew/bin/enclaude" hook-handler session-end`, true},
+		{"'/path with spaces/enclaude' hook-handler session-start", true},
+		{"'/it'\\''s here/enclaude' hook-handler session-end", false}, // malformed after split, acceptable
 		// Should NOT match
 		{"some-script --enclaude --hook-handler", false},
 		{"/path/to/hook-handler enclaude", false},

--- a/internal/gitops/hooks_test.go
+++ b/internal/gitops/hooks_test.go
@@ -203,7 +203,8 @@ func TestContainsMarker(t *testing.T) {
 		{"/Users/bogdan/go/bin/enclaude hook-handler session-start", true},
 		{`"/opt/homebrew/bin/enclaude" hook-handler session-end`, true},
 		{"'/path with spaces/enclaude' hook-handler session-start", true},
-		{"'/it'\\''s here/enclaude' hook-handler session-end", true}, // escaped apostrophe via '\''
+		{"'/it'\\''s here/enclaude' hook-handler session-end", true},  // escaped apostrophe via '\''
+		{"'/usr/local/bin/enclaude'\nhook-handler session-start", true}, // newline as token separator
 		// Should NOT match
 		{"some-script --enclaude --hook-handler", false},
 		{"/path/to/hook-handler enclaude", false},

--- a/internal/gitops/hooks_test.go
+++ b/internal/gitops/hooks_test.go
@@ -211,6 +211,9 @@ func TestContainsMarker(t *testing.T) {
 		{"/path/to/not-enclaude hook-handler session-start", false},
 		{"enclaude hook-handler-wrapper session-start", false},
 		{"'/path/enclaude' hook-handler2", false},
+		// Quoted+unquoted concatenation (POSIX: single token)
+		{"'/path/enclaude'hook-handler session-start", false},
+		{"enclaude 'hook-handler'wrapper session-start", false},
 		{"peon.sh", false},
 		{"", false},
 	}

--- a/internal/gitops/hooks_test.go
+++ b/internal/gitops/hooks_test.go
@@ -280,6 +280,8 @@ func TestIsLegacyHook(t *testing.T) {
 		{"/usr/local/bin/enclaude hook-handler session-end", true},
 		{"'/path/to/enclaude' hook-handler session-start", true},
 		// Not legacy
+		{"enclaude-wrapper hook-handler session-start", false},
+		{"/usr/local/bin/enclaude-proxy hook-handler session-end", false},
 		{"/path/to/peon-ping/peon.sh", false},
 		{"some-random-script --foo", false},
 		{"", false},

--- a/internal/gitops/hooks_test.go
+++ b/internal/gitops/hooks_test.go
@@ -8,6 +8,14 @@ import (
 	"testing"
 )
 
+func TestMain(m *testing.M) {
+	// Override executable resolver so tests get a predictable command path
+	resolveExecutable = func() (string, error) {
+		return "/usr/local/bin/enclaude", nil
+	}
+	os.Exit(m.Run())
+}
+
 func TestInstallHooksPreservesExisting(t *testing.T) {
 	dir := t.TempDir()
 
@@ -80,10 +88,10 @@ func TestInstallHooksPreservesExisting(t *testing.T) {
 	}
 
 	// Verify seal hooks added
-	if !strings.Contains(resultStr, "enclaude hook-handler session-start") {
+	if !strings.Contains(resultStr, "/usr/local/bin/enclaude hook-handler session-start") {
 		t.Error("session-start hook not added")
 	}
-	if !strings.Contains(resultStr, "enclaude hook-handler session-end") {
+	if !strings.Contains(resultStr, "/usr/local/bin/enclaude hook-handler session-end") {
 		t.Error("session-end hook not added")
 	}
 
@@ -113,7 +121,7 @@ func TestInstallHooksIdempotent(t *testing.T) {
 
 	result, _ := os.ReadFile(filepath.Join(dir, "settings.json"))
 	// Count occurrences — should only appear once
-	count := strings.Count(string(result), "enclaude hook-handler session-start")
+	count := strings.Count(string(result), "/usr/local/bin/enclaude hook-handler session-start")
 	if count != 1 {
 		t.Errorf("hook-handler session-start appears %d times, expected 1", count)
 	}

--- a/internal/gitops/hooks_test.go
+++ b/internal/gitops/hooks_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// Override executable resolver so tests get a predictable command path
 	resolveExecutable = func() (string, error) {
 		return "/usr/local/bin/enclaude", nil
 	}
@@ -19,33 +18,16 @@ func TestMain(m *testing.M) {
 func TestInstallHooksPreservesExisting(t *testing.T) {
 	dir := t.TempDir()
 
-	// Write a settings.json with existing hooks (simulating peon-ping, notchi)
 	existing := map[string]any{
-		"env": map[string]any{
-			"ENABLE_LSP_TOOL": "1",
-		},
+		"env": map[string]any{"ENABLE_LSP_TOOL": "1"},
 		"hooks": map[string]any{
 			"SessionStart": []any{
 				map[string]any{
-					"matcher": "",
 					"hooks": []any{
 						map[string]any{
 							"type":    "command",
 							"command": "/path/to/peon-ping/peon.sh",
 							"timeout": 10,
-						},
-					},
-				},
-			},
-			"SessionEnd": []any{
-				map[string]any{
-					"matcher": "",
-					"hooks": []any{
-						map[string]any{
-							"type":    "command",
-							"command": "/path/to/peon-ping/peon.sh",
-							"timeout": 10,
-							"async":   true,
 						},
 					},
 				},
@@ -70,43 +52,25 @@ func TestInstallHooksPreservesExisting(t *testing.T) {
 	data, _ := json.MarshalIndent(existing, "", "  ")
 	os.WriteFile(filepath.Join(dir, "settings.json"), data, 0644)
 
-	// Install hooks
 	if err := InstallHooks(dir); err != nil {
 		t.Fatalf("InstallHooks() error: %v", err)
 	}
 
-	// Read back
 	result, _ := os.ReadFile(filepath.Join(dir, "settings.json"))
 	resultStr := string(result)
 
-	// Verify existing hooks preserved
 	if !strings.Contains(resultStr, "peon-ping/peon.sh") {
 		t.Error("peon-ping hook was removed")
 	}
 	if !strings.Contains(resultStr, "rtk-rewrite.sh") {
 		t.Error("rtk-rewrite hook was removed")
 	}
-
-	// Verify seal hooks added with marker
-	if !strings.Contains(resultStr, "hook-handler session-start") {
-		t.Error("session-start hook not added")
-	}
-	if !strings.Contains(resultStr, "hook-handler session-end") {
-		t.Error("session-end hook not added")
-	}
 	if strings.Count(resultStr, hookMarker) != 2 {
-		t.Error("expected exactly 2 hook markers (SessionStart + SessionEnd)")
+		t.Error("expected exactly 2 hook markers")
 	}
-
-	// Verify non-hook settings preserved
 	if !strings.Contains(resultStr, "ENABLE_LSP_TOOL") {
 		t.Error("env settings lost")
 	}
-	if !strings.Contains(resultStr, "enabledPlugins") {
-		t.Error("enabledPlugins lost")
-	}
-
-	// Verify installed
 	if !HooksInstalled(dir) {
 		t.Error("HooksInstalled() returned false after install")
 	}
@@ -118,14 +82,68 @@ func TestInstallHooksIdempotent(t *testing.T) {
 	data, _ := json.MarshalIndent(settings, "", "  ")
 	os.WriteFile(filepath.Join(dir, "settings.json"), data, 0644)
 
-	// Install twice
 	InstallHooks(dir)
 	InstallHooks(dir)
 
 	result, _ := os.ReadFile(filepath.Join(dir, "settings.json"))
 	count := strings.Count(string(result), hookMarker)
-	if count != 2 { // one per event (SessionStart + SessionEnd)
+	if count != 2 {
 		t.Errorf("hook marker appears %d times, expected 2", count)
+	}
+}
+
+func TestInstallHooksMigratesLegacy(t *testing.T) {
+	dir := t.TempDir()
+
+	// Simulate a settings.json with legacy (pre-marker) hooks
+	existing := map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{
+				map[string]any{
+					"hooks": []any{
+						map[string]any{
+							"type":    "command",
+							"command": "enclaude hook-handler session-start",
+							"timeout": 30,
+						},
+					},
+				},
+			},
+			"SessionEnd": []any{
+				map[string]any{
+					"hooks": []any{
+						map[string]any{
+							"type":    "command",
+							"command": "/old/path/enclaude hook-handler session-end",
+							"timeout": 60,
+							"async":   true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	data, _ := json.MarshalIndent(existing, "", "  ")
+	os.WriteFile(filepath.Join(dir, "settings.json"), data, 0644)
+
+	if err := InstallHooks(dir); err != nil {
+		t.Fatalf("InstallHooks() error: %v", err)
+	}
+
+	result, _ := os.ReadFile(filepath.Join(dir, "settings.json"))
+	resultStr := string(result)
+
+	// Legacy hooks should be migrated, not duplicated
+	if strings.Count(resultStr, hookMarker) != 2 {
+		t.Errorf("expected 2 markers after migration, got %d", strings.Count(resultStr, hookMarker))
+	}
+	// Should use current binary path, not old one
+	if strings.Contains(resultStr, "/old/path/enclaude") {
+		t.Error("legacy path was not replaced")
+	}
+	if !HooksInstalled(dir) {
+		t.Error("HooksInstalled() returned false after migration")
 	}
 }
 
@@ -135,7 +153,6 @@ func TestRemoveHooksPreservesOthers(t *testing.T) {
 	data, _ := json.MarshalIndent(settings, "", "  ")
 	os.WriteFile(filepath.Join(dir, "settings.json"), data, 0644)
 
-	// Install then remove
 	InstallHooks(dir)
 
 	if !HooksInstalled(dir) {
@@ -148,6 +165,50 @@ func TestRemoveHooksPreservesOthers(t *testing.T) {
 
 	if HooksInstalled(dir) {
 		t.Error("hooks should be removed")
+	}
+}
+
+func TestRemoveHandlesBothFormats(t *testing.T) {
+	dir := t.TempDir()
+
+	// Mix of legacy and marker hooks
+	existing := map[string]any{
+		"hooks": map[string]any{
+			"SessionStart": []any{
+				map[string]any{
+					"hooks": []any{
+						map[string]any{
+							"type":    "command",
+							"command": "enclaude hook-handler session-start",
+						},
+					},
+				},
+			},
+			"SessionEnd": []any{
+				map[string]any{
+					"hooks": []any{
+						map[string]any{
+							"type":    "command",
+							"command": "'/usr/local/bin/enclaude' hook-handler session-end  " + hookMarker,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	data, _ := json.MarshalIndent(existing, "", "  ")
+	os.WriteFile(filepath.Join(dir, "settings.json"), data, 0644)
+
+	if err := RemoveHooks(dir); err != nil {
+		t.Fatalf("RemoveHooks() error: %v", err)
+	}
+
+	result, _ := os.ReadFile(filepath.Join(dir, "settings.json"))
+	resultStr := string(result)
+
+	if strings.Contains(resultStr, "enclaude") {
+		t.Error("enclaude hooks should be fully removed")
 	}
 }
 
@@ -191,28 +252,122 @@ func TestSymlinkNotResolved(t *testing.T) {
 	}
 }
 
-func TestContainsMarker(t *testing.T) {
+func TestHasMarker(t *testing.T) {
 	tests := []struct {
 		cmd  string
 		want bool
 	}{
-		// New-style: marker comment present
 		{"enclaude hook-handler session-start  " + hookMarker, true},
 		{"'/usr/local/bin/enclaude' hook-handler session-end  " + hookMarker, true},
-		{"'/path with spaces/enclaude' hook-handler session-start  " + hookMarker, true},
-		// Legacy: no marker but contains "enclaude hook-handler"
+		// No marker
+		{"enclaude hook-handler session-start", false},
+		{"/path/to/peon-ping/peon.sh", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := hasMarker(tt.cmd); got != tt.want {
+			t.Errorf("hasMarker(%q) = %v, want %v", tt.cmd, got, tt.want)
+		}
+	}
+}
+
+func TestIsLegacyHook(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want bool
+	}{
 		{"enclaude hook-handler session-start", true},
-		{"'/usr/local/bin/enclaude' hook-handler session-end", true},
-		{"/Users/bogdan/go/bin/enclaude hook-handler session-start", true},
-		// Should NOT match
+		{"/usr/local/bin/enclaude hook-handler session-end", true},
+		{"'/path/to/enclaude' hook-handler session-start", true},
+		// Not legacy
 		{"/path/to/peon-ping/peon.sh", false},
 		{"some-random-script --foo", false},
 		{"", false},
 	}
 	for _, tt := range tests {
-		if got := containsMarker(tt.cmd); got != tt.want {
-			t.Errorf("containsMarker(%q) = %v, want %v", tt.cmd, got, tt.want)
+		if got := isLegacyHook(tt.cmd); got != tt.want {
+			t.Errorf("isLegacyHook(%q) = %v, want %v", tt.cmd, got, tt.want)
 		}
+	}
+}
+
+func TestExtractAction(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want string
+	}{
+		{"enclaude hook-handler session-start", "session-start"},
+		{"'/usr/local/bin/enclaude' hook-handler session-end", "session-end"},
+		{"/path/enclaude hook-handler session-start  " + hookMarker, "session-start"},
+		{"enclaude hook-handler", ""},
+		{"peon.sh", ""},
+	}
+	for _, tt := range tests {
+		if got := extractAction(tt.cmd); got != tt.want {
+			t.Errorf("extractAction(%q) = %q, want %q", tt.cmd, got, tt.want)
+		}
+	}
+}
+
+func TestMigrateLegacyHooks(t *testing.T) {
+	hooks := map[string]json.RawMessage{}
+
+	// Legacy SessionStart
+	startEntries := []hookEntry{
+		{Hooks: []hookDef{{
+			Type:    "command",
+			Command: "enclaude hook-handler session-start",
+			Timeout: 30,
+		}}},
+	}
+	startData, _ := json.Marshal(startEntries)
+	hooks["SessionStart"] = startData
+
+	// Non-enclaude hook (should be untouched)
+	otherEntries := []hookEntry{
+		{Hooks: []hookDef{{
+			Type:    "command",
+			Command: "/path/to/peon.sh",
+		}}},
+	}
+	otherData, _ := json.Marshal(otherEntries)
+	hooks["PreToolUse"] = otherData
+
+	n := migrateLegacyHooks(hooks)
+	if n != 1 {
+		t.Errorf("expected 1 migration, got %d", n)
+	}
+
+	// Verify migrated hook has marker
+	var result []hookEntry
+	json.Unmarshal(hooks["SessionStart"], &result)
+	if !hasMarker(result[0].Hooks[0].Command) {
+		t.Errorf("migrated hook missing marker: %s", result[0].Hooks[0].Command)
+	}
+
+	// Verify other hooks untouched
+	var others []hookEntry
+	json.Unmarshal(hooks["PreToolUse"], &others)
+	if others[0].Hooks[0].Command != "/path/to/peon.sh" {
+		t.Errorf("non-enclaude hook was modified: %s", others[0].Hooks[0].Command)
+	}
+}
+
+func TestMigrateLegacySkipsAlreadyMigrated(t *testing.T) {
+	hooks := map[string]json.RawMessage{}
+
+	entries := []hookEntry{
+		{Hooks: []hookDef{{
+			Type:    "command",
+			Command: sealHookFull("session-start"),
+		}}},
+	}
+	data, _ := json.Marshal(entries)
+	hooks["SessionStart"] = data
+
+	n := migrateLegacyHooks(hooks)
+	if n != 0 {
+		t.Errorf("expected 0 migrations for already-migrated hooks, got %d", n)
 	}
 }
 

--- a/internal/gitops/hooks_test.go
+++ b/internal/gitops/hooks_test.go
@@ -20,16 +20,16 @@ func TestInstallHooksPreservesExisting(t *testing.T) {
 	dir := t.TempDir()
 
 	// Write a settings.json with existing hooks (simulating peon-ping, notchi)
-	existing := map[string]interface{}{
-		"env": map[string]interface{}{
+	existing := map[string]any{
+		"env": map[string]any{
 			"ENABLE_LSP_TOOL": "1",
 		},
-		"hooks": map[string]interface{}{
-			"SessionStart": []interface{}{
-				map[string]interface{}{
+		"hooks": map[string]any{
+			"SessionStart": []any{
+				map[string]any{
 					"matcher": "",
-					"hooks": []interface{}{
-						map[string]interface{}{
+					"hooks": []any{
+						map[string]any{
 							"type":    "command",
 							"command": "/path/to/peon-ping/peon.sh",
 							"timeout": 10,
@@ -37,11 +37,11 @@ func TestInstallHooksPreservesExisting(t *testing.T) {
 					},
 				},
 			},
-			"SessionEnd": []interface{}{
-				map[string]interface{}{
+			"SessionEnd": []any{
+				map[string]any{
 					"matcher": "",
-					"hooks": []interface{}{
-						map[string]interface{}{
+					"hooks": []any{
+						map[string]any{
 							"type":    "command",
 							"command": "/path/to/peon-ping/peon.sh",
 							"timeout": 10,
@@ -50,11 +50,11 @@ func TestInstallHooksPreservesExisting(t *testing.T) {
 					},
 				},
 			},
-			"PreToolUse": []interface{}{
-				map[string]interface{}{
+			"PreToolUse": []any{
+				map[string]any{
 					"matcher": "Bash",
-					"hooks": []interface{}{
-						map[string]interface{}{
+					"hooks": []any{
+						map[string]any{
 							"type":    "command",
 							"command": "/path/to/rtk-rewrite.sh",
 						},
@@ -62,7 +62,7 @@ func TestInstallHooksPreservesExisting(t *testing.T) {
 				},
 			},
 		},
-		"enabledPlugins": map[string]interface{}{
+		"enabledPlugins": map[string]any{
 			"linear@claude-plugins-official": true,
 		},
 	}
@@ -87,12 +87,15 @@ func TestInstallHooksPreservesExisting(t *testing.T) {
 		t.Error("rtk-rewrite hook was removed")
 	}
 
-	// Verify seal hooks added
-	if !strings.Contains(resultStr, "'/usr/local/bin/enclaude' hook-handler session-start") {
+	// Verify seal hooks added with marker
+	if !strings.Contains(resultStr, "hook-handler session-start") {
 		t.Error("session-start hook not added")
 	}
-	if !strings.Contains(resultStr, "'/usr/local/bin/enclaude' hook-handler session-end") {
+	if !strings.Contains(resultStr, "hook-handler session-end") {
 		t.Error("session-end hook not added")
+	}
+	if strings.Count(resultStr, hookMarker) != 2 {
+		t.Error("expected exactly 2 hook markers (SessionStart + SessionEnd)")
 	}
 
 	// Verify non-hook settings preserved
@@ -111,7 +114,7 @@ func TestInstallHooksPreservesExisting(t *testing.T) {
 
 func TestInstallHooksIdempotent(t *testing.T) {
 	dir := t.TempDir()
-	settings := map[string]interface{}{"hooks": map[string]interface{}{}}
+	settings := map[string]any{"hooks": map[string]any{}}
 	data, _ := json.MarshalIndent(settings, "", "  ")
 	os.WriteFile(filepath.Join(dir, "settings.json"), data, 0644)
 
@@ -120,16 +123,15 @@ func TestInstallHooksIdempotent(t *testing.T) {
 	InstallHooks(dir)
 
 	result, _ := os.ReadFile(filepath.Join(dir, "settings.json"))
-	// Count occurrences — should only appear once
-	count := strings.Count(string(result), "'/usr/local/bin/enclaude' hook-handler session-start")
-	if count != 1 {
-		t.Errorf("hook-handler session-start appears %d times, expected 1", count)
+	count := strings.Count(string(result), hookMarker)
+	if count != 2 { // one per event (SessionStart + SessionEnd)
+		t.Errorf("hook marker appears %d times, expected 2", count)
 	}
 }
 
 func TestRemoveHooksPreservesOthers(t *testing.T) {
 	dir := t.TempDir()
-	settings := map[string]interface{}{"hooks": map[string]interface{}{}}
+	settings := map[string]any{"hooks": map[string]any{}}
 	data, _ := json.MarshalIndent(settings, "", "  ")
 	os.WriteFile(filepath.Join(dir, "settings.json"), data, 0644)
 
@@ -177,9 +179,6 @@ func TestShellQuoteHandlesSingleQuotes(t *testing.T) {
 }
 
 func TestSymlinkNotResolved(t *testing.T) {
-	// sealHookCommand should use the path as-is from os.Executable,
-	// not chase symlinks. We verify by checking the output matches
-	// the value returned by resolveExecutable directly.
 	old := resolveExecutable
 	resolveExecutable = func() (string, error) {
 		return "/opt/homebrew/bin/enclaude", nil
@@ -197,31 +196,34 @@ func TestContainsMarker(t *testing.T) {
 		cmd  string
 		want bool
 	}{
-		// Should match
-		{"enclaude hook-handler session-start", true},
-		{"'/usr/local/bin/enclaude' hook-handler session-end", true},
-		{"/Users/bogdan/go/bin/enclaude hook-handler session-start", true},
-		{`"/opt/homebrew/bin/enclaude" hook-handler session-end`, true},
-		{"'/path with spaces/enclaude' hook-handler session-start", true},
-		{"'/it'\\''s here/enclaude' hook-handler session-end", true},  // escaped apostrophe via '\''
-		{"'/usr/local/bin/enclaude'\nhook-handler session-start", true}, // newline as token separator
-		// Should NOT match
+		// Should match — any command containing the marker comment
+		{"enclaude hook-handler session-start  " + hookMarker, true},
+		{"'/usr/local/bin/enclaude' hook-handler session-end  " + hookMarker, true},
+		{"'/path with spaces/enclaude' hook-handler session-start  " + hookMarker, true},
+		// Should NOT match — no marker comment
+		{"enclaude hook-handler session-start", false},
+		{"'/usr/local/bin/enclaude' hook-handler session-end", false},
 		{"some-script --enclaude --hook-handler", false},
-		{"/path/to/hook-handler enclaude", false},
-		{"enclaude-wrapper hook-handler session-start", false},
-		{"/path/to/not-enclaude hook-handler session-start", false},
-		{"enclaude hook-handler-wrapper session-start", false},
-		{"'/path/enclaude' hook-handler2", false},
-		// Quoted+unquoted concatenation (POSIX: single token)
-		{"'/path/enclaude'hook-handler session-start", false},
-		{"enclaude 'hook-handler'wrapper session-start", false},
-		{"peon.sh", false},
+		{"/path/to/peon-ping/peon.sh", false},
 		{"", false},
 	}
 	for _, tt := range tests {
 		if got := containsMarker(tt.cmd); got != tt.want {
 			t.Errorf("containsMarker(%q) = %v, want %v", tt.cmd, got, tt.want)
 		}
+	}
+}
+
+func TestSealHookFullIncludesMarker(t *testing.T) {
+	cmd := sealHookFull("session-start")
+	if !strings.Contains(cmd, hookMarker) {
+		t.Errorf("sealHookFull missing marker: %s", cmd)
+	}
+	if !strings.Contains(cmd, "session-start") {
+		t.Errorf("sealHookFull missing action: %s", cmd)
+	}
+	if !strings.Contains(cmd, "/usr/local/bin/enclaude") {
+		t.Errorf("sealHookFull missing executable path: %s", cmd)
 	}
 }
 

--- a/internal/gitops/hooks_test.go
+++ b/internal/gitops/hooks_test.go
@@ -88,10 +88,10 @@ func TestInstallHooksPreservesExisting(t *testing.T) {
 	}
 
 	// Verify seal hooks added
-	if !strings.Contains(resultStr, "/usr/local/bin/enclaude hook-handler session-start") {
+	if !strings.Contains(resultStr, "'/usr/local/bin/enclaude' hook-handler session-start") {
 		t.Error("session-start hook not added")
 	}
-	if !strings.Contains(resultStr, "/usr/local/bin/enclaude hook-handler session-end") {
+	if !strings.Contains(resultStr, "'/usr/local/bin/enclaude' hook-handler session-end") {
 		t.Error("session-end hook not added")
 	}
 
@@ -121,7 +121,7 @@ func TestInstallHooksIdempotent(t *testing.T) {
 
 	result, _ := os.ReadFile(filepath.Join(dir, "settings.json"))
 	// Count occurrences — should only appear once
-	count := strings.Count(string(result), "/usr/local/bin/enclaude hook-handler session-start")
+	count := strings.Count(string(result), "'/usr/local/bin/enclaude' hook-handler session-start")
 	if count != 1 {
 		t.Errorf("hook-handler session-start appears %d times, expected 1", count)
 	}
@@ -146,6 +146,49 @@ func TestRemoveHooksPreservesOthers(t *testing.T) {
 
 	if HooksInstalled(dir) {
 		t.Error("hooks should be removed")
+	}
+}
+
+func TestShellQuoteHandlesSpaces(t *testing.T) {
+	old := resolveExecutable
+	resolveExecutable = func() (string, error) {
+		return "/path with spaces/enclaude", nil
+	}
+	defer func() { resolveExecutable = old }()
+
+	cmd := sealHookCommand()
+	if cmd != "'/path with spaces/enclaude' hook-handler" {
+		t.Errorf("unexpected command: %s", cmd)
+	}
+}
+
+func TestShellQuoteHandlesSingleQuotes(t *testing.T) {
+	old := resolveExecutable
+	resolveExecutable = func() (string, error) {
+		return "/it's/enclaude", nil
+	}
+	defer func() { resolveExecutable = old }()
+
+	cmd := sealHookCommand()
+	expected := `'/it'\''s/enclaude' hook-handler`
+	if cmd != expected {
+		t.Errorf("unexpected command: got %s, want %s", cmd, expected)
+	}
+}
+
+func TestSymlinkNotResolved(t *testing.T) {
+	// sealHookCommand should use the path as-is from os.Executable,
+	// not chase symlinks. We verify by checking the output matches
+	// the value returned by resolveExecutable directly.
+	old := resolveExecutable
+	resolveExecutable = func() (string, error) {
+		return "/opt/homebrew/bin/enclaude", nil
+	}
+	defer func() { resolveExecutable = old }()
+
+	cmd := sealHookCommand()
+	if cmd != "'/opt/homebrew/bin/enclaude' hook-handler" {
+		t.Errorf("unexpected command (symlink may have been resolved): %s", cmd)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Use absolute binary path in hooks** — hooks run via `/bin/sh` which doesn't have `~/go/bin` in PATH, causing `enclaude: command not found` on session start/end
- **Shell-quote the path** — handles spaces and special characters in install paths
- **Preserve symlinks** — don't resolve symlinks (e.g. Homebrew) since they're stable across upgrades while targets are versioned
- **Marker-based detection** — append `# enclaude-managed` shell comment to hook commands for reliable detection without shell parsing
- **Legacy migration** — `hooks install` upgrades pre-marker hooks in-place so detection can use marker-only checks (no false positives)
- **Remove stale `claude-vault` hooks** from settings (leftover from the rename)

## Test plan

- [x] `go test ./... -count=1` — 66 tests pass
- [x] `enclaude hooks install` writes absolute path with marker
- [x] Legacy hooks (bare, absolute path, quoted) are migrated on install
- [x] `enclaude hooks remove` handles both legacy and marker formats
- [x] Idempotent: installing twice doesn't duplicate hooks
- [x] Non-enclaude hooks (peon-ping, rtk, notchi) are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)