### PR TITLE
Added remote remove and remote edit command

### DIFF
--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -56,8 +56,24 @@ var remoteListCmd = &cobra.Command{
 	},
 }
 
+var remoteRemoveCmd = &cobra.Command{
+	Use:   "remove <name>",
+	Short: "Remove a git remote",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		git := gitops.New(getSealDir())
+		name := args[0]
+		if err := git.RemoteRemove(name); err != nil {
+			return fmt.Errorf("removing remote: %w", err)
+		}
+		fmt.Printf("Remote '%s' removed.\n", name)
+		return nil
+	},
+}
+
 func init() {
 	remoteCmd.AddCommand(remoteAddCmd)
 	remoteCmd.AddCommand(remoteListCmd)
+	remoteCmd.AddCommand(remoteRemoveCmd)
 	rootCmd.AddCommand(remoteCmd)
 }

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -71,9 +71,25 @@ var remoteRemoveCmd = &cobra.Command{
 	},
 }
 
+var remoteEditCmd = &cobra.Command{
+	Use:   "edit <name> <url>",
+	Short: "Update the URL of an existing git remote",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		git := gitops.New(getSealDir())
+		name, url := args[0], args[1]
+		if err := git.RemoteSetURL(name, url); err != nil {
+			return fmt.Errorf("editing remote: %w", err)
+		}
+		fmt.Printf("Remote '%s' updated: %s\n", name, url)
+		return nil
+	},
+}
+
 func init() {
 	remoteCmd.AddCommand(remoteAddCmd)
 	remoteCmd.AddCommand(remoteListCmd)
 	remoteCmd.AddCommand(remoteRemoveCmd)
+	remoteCmd.AddCommand(remoteEditCmd)
 	rootCmd.AddCommand(remoteCmd)
 }

--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -101,6 +101,12 @@ func (g *Git) RemoteRemove(name string) error {
 	return err
 }
 
+// RemoteSetURL updates the URL of an existing git remote.
+func (g *Git) RemoteSetURL(name, url string) error {
+	_, err := g.run("remote", "set-url", name, url)
+	return err
+}
+
 // CurrentBranch returns the current branch name.
 func (g *Git) CurrentBranch() (string, error) {
 	return g.run("rev-parse", "--abbrev-ref", "HEAD")

--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -95,6 +95,12 @@ func (g *Git) RemoteList() (string, error) {
 	return g.run("remote", "-v")
 }
 
+// RemoteRemove removes a git remote.
+func (g *Git) RemoteRemove(name string) error {
+	_, err := g.run("remote", "remove", name)
+	return err
+}
+
 // CurrentBranch returns the current branch name.
 func (g *Git) CurrentBranch() (string, error) {
 	return g.run("rev-parse", "--abbrev-ref", "HEAD")


### PR DESCRIPTION
I PEBCAK'd adding my remote, I'd like to be able to remove or edit the one I've set. So! 

This pull request adds new functionality to manage git remotes through the CLI by introducing commands to remove and edit remotes. It also implements the corresponding methods in the internal git operations package.

**New CLI commands for git remote management:**

* Added `remote remove <name>` command to allow users to remove a git remote from their enclaude config.
* Added `remote edit <name> <url>` command to update the URL of an existing git remote.

**Internal git operations enhancements:**

* Implemented `RemoteRemove` method in `internal/gitops/git.go` to support removing a remote.
* Implemented `RemoteSetURL` method in `internal/gitops/git.go` to support updating a remote's URL.