### PR TITLE
Add minimal CI workflow: build + test on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go build ./...
+
+      - run: go test ./... -count=1


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` — first CI workflow in the repo.
- Runs `go build ./...` and `go test ./... -count=1` on `ubuntu-latest` for every PR and every push to `main`.
- Uses `go-version-file: go.mod` so the toolchain tracks the module declaration; no drift between `go.mod` and a pinned YAML version.

## Why
Now that the project is receiving external PRs (#3), contributors deserve an automated build+test signal on their changes before review.

## Scope — intentionally minimal
- Single OS (`ubuntu-latest`). `git` is preinstalled, no CGO, no external services.
- No lint step (no `.golangci.yml` exists yet — cleaner as a follow-up PR).
- No matrix, no release artifacts, no coverage — all out of scope for a first-pass "does it compile and do tests pass" gate.

## Test plan
- [x] `go build ./...` passes locally on current `main`.
- [x] `go test ./... -count=1` passes locally on current `main`.
- [ ] GitHub Actions "CI / build-test" check runs on this PR and goes green.
- [ ] After merge, the `push` trigger fires on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)