### PR TITLE
CI: cross-compile release targets to match goreleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  build-test:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,6 +15,24 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - run: go build ./...
-
       - run: go test ./... -count=1
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, darwin]
+        goarch: [amd64, arm64]
+    env:
+      CGO_ENABLED: "0"
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go build ./...


### PR DESCRIPTION
## Summary
- Splits the CI workflow into `test` (single Linux runner) and `build` (matrix of linux/darwin × amd64/arm64, CGO_ENABLED=0 — matching `.goreleaser.yaml`).
- Catches platform-specific compile errors (e.g., keyring backends differ per OS) that the previous native-only workflow would miss.

## Why
Roborev review (job 742) flagged that the original workflow could pass even if the goreleaser release build broke on a non-Linux target. This closes that gap without expanding scope to full cross-platform test execution.

## Test plan
- [x] Verified cross-compile succeeds locally for all four targets (`GOOS=linux/darwin`, `GOARCH=amd64/arm64`, `CGO_ENABLED=0`).
- [ ] CI job `test` passes.
- [ ] CI job `build` passes across all 4 matrix cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)