### PR TITLE
Added README.md generation to enclaude init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -146,46 +146,60 @@ func runInit(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+const readmeTemplate = `# enclaude seal store
+
+This repository contains an encrypted backup of a Claude Code configuration
+directory, managed by [enclaude](https://github.com/coredipper/enclaude).
+
+All files are encrypted with [age](https://age-encryption.org/) and cannot be
+read without the private key stored in the OS keychain on the originating device.
+
+> **Private keys are never stored here.** The age private key lives exclusively
+> in the OS keychain (and optionally in an encrypted backup file). Do not commit
+> private keys or unencrypted backups to this repository.
+
+## Repository details
+
+| Field      | Value                    |
+|------------|--------------------------|
+| Public key | {PUBLIC_KEY} |
+| Device ID  | {DEVICE_ID} |
+
+## Restoring on a new machine
+
+1. Install enclaude.
+2. Clone this repository to {T}~/.enclaude/{T}:
+   {T}git clone <remote-url> ~/.enclaude{T}
+3. Import your private key into the keychain:
+   {T}enclaude key import{T}
+4. Decrypt and restore your Claude files:
+   {T}enclaude unseal{T}
+
+## Key recovery
+
+If the OS keychain entry is lost, restore from the passphrase-encrypted backup:
+
+{F}
+enclaude key recover key.age.backup
+{F}
+
+You will be prompted for the passphrase you set during {T}enclaude init{T}.
+
+## Daily use
+
+{F}
+enclaude seal          # encrypt and commit changes
+enclaude push          # push to remote
+enclaude pull          # pull and decrypt latest
+enclaude status        # show unsealed changes not yet sealed
+{F}
+`
+
 func buildReadme(publicKey, deviceID string) string {
-	tick := "`"
-	fence := "```"
-	return fmt.Sprintf(
-		"# enclaude seal store\n\n"+
-			"This repository contains an encrypted backup of a Claude Code configuration\n"+
-			"directory, managed by [enclaude](https://github.com/coredipper/enclaude).\n\n"+
-			"All files are encrypted with [age](https://age-encryption.org/) and cannot be\n"+
-			"read without the private key stored in the OS keychain on the originating device.\n\n"+
-			"> **Private keys are never stored here.** The age private key lives exclusively\n"+
-			"> in the OS keychain (and optionally in an encrypted backup file). Do not commit\n"+
-			"> private keys or unencrypted backups to this repository.\n\n"+
-			"## Repository details\n\n"+
-			"| Field      | Value                    |\n"+
-			"|------------|---------------------------|\n"+
-			"| Public key | %s |\n"+
-			"| Device ID  | %s |\n\n"+
-			"## Restoring on a new machine\n\n"+
-			"1. Install enclaude.\n"+
-			"2. Clone this repository to %s~/.enclaude/%s:\n"+
-			"   %sgit clone <remote-url> ~/.enclaude%s\n"+
-			"3. Import your private key into the keychain:\n"+
-			"   %senclaude key import%s\n"+
-			"4. Decrypt and restore your Claude files:\n"+
-			"   %senclaude unseal%s\n\n"+
-			"## Key recovery\n\n"+
-			"If the OS keychain entry is lost, restore from the passphrase-encrypted backup:\n\n"+
-			fence+"\n"+
-			"enclaude key recover key.age.backup\n"+
-			fence+"\n\n"+
-			"You will be prompted for the passphrase you set during %senclaude init%s.\n\n"+
-			"## Daily use\n\n"+
-			fence+"\n"+
-			"enclaude seal          # encrypt and commit changes\n"+
-			"enclaude push          # push to remote\n"+
-			"enclaude pull          # pull and decrypt latest\n"+
-			"enclaude status        # show unsealed changes not yet sealed\n"+
-			fence+"\n",
-		publicKey, deviceID,
-		tick, tick, tick, tick, tick, tick, tick, tick,
-		tick, tick,
-	)
+	return strings.NewReplacer(
+		"{PUBLIC_KEY}", publicKey,
+		"{DEVICE_ID}", deviceID,
+		"{T}", "`",
+		"{F}", "```",
+	).Replace(readmeTemplate)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -111,6 +111,12 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("writing .gitignore: %w", err)
 	}
 
+	// Write README
+	readme := buildReadme(identity.Recipient().String(), cfg.Seal.DeviceID)
+	if err := os.WriteFile(filepath.Join(sealDir, "README.md"), []byte(readme), 0644); err != nil {
+		return fmt.Errorf("writing README: %w", err)
+	}
+
 	// 7. Initial seal
 	fmt.Println("\nPerforming initial seal...")
 	stats, err := store.Seal(cfg, identity.Recipient(), flagVerbose, nil)
@@ -138,4 +144,48 @@ func runInit(cmd *cobra.Command, args []string) error {
 	fmt.Println("  1. enclaude remote add origin <url>   # set up sync remote")
 	fmt.Println("  2. enclaude hooks install              # enable auto-sync")
 	return nil
+}
+
+func buildReadme(publicKey, deviceID string) string {
+	tick := "`"
+	fence := "```"
+	return fmt.Sprintf(
+		"# enclaude seal store\n\n"+
+			"This repository contains an encrypted backup of a Claude Code configuration\n"+
+			"directory, managed by [enclaude](https://github.com/coredipper/enclaude).\n\n"+
+			"All files are encrypted with [age](https://age-encryption.org/) and cannot be\n"+
+			"read without the private key stored in the OS keychain on the originating device.\n\n"+
+			"> **Private keys are never stored here.** The age private key lives exclusively\n"+
+			"> in the OS keychain (and optionally in an encrypted backup file). Do not commit\n"+
+			"> private keys or unencrypted backups to this repository.\n\n"+
+			"## Repository details\n\n"+
+			"| Field      | Value                    |\n"+
+			"|------------|---------------------------|\n"+
+			"| Public key | %s |\n"+
+			"| Device ID  | %s |\n\n"+
+			"## Restoring on a new machine\n\n"+
+			"1. Install enclaude.\n"+
+			"2. Clone this repository to %s~/.enclaude/%s:\n"+
+			"   %sgit clone <remote-url> ~/.enclaude%s\n"+
+			"3. Import your private key into the keychain:\n"+
+			"   %senclaude key import%s\n"+
+			"4. Decrypt and restore your Claude files:\n"+
+			"   %senclaude unseal%s\n\n"+
+			"## Key recovery\n\n"+
+			"If the OS keychain entry is lost, restore from the passphrase-encrypted backup:\n\n"+
+			fence+"\n"+
+			"enclaude key recover key.age.backup\n"+
+			fence+"\n\n"+
+			"You will be prompted for the passphrase you set during %senclaude init%s.\n\n"+
+			"## Daily use\n\n"+
+			fence+"\n"+
+			"enclaude seal          # encrypt and commit changes\n"+
+			"enclaude push          # push to remote\n"+
+			"enclaude pull          # pull and decrypt latest\n"+
+			"enclaude status        # show unsealed changes not yet sealed\n"+
+			fence+"\n",
+		publicKey, deviceID,
+		tick, tick, tick, tick, tick, tick, tick, tick,
+		tick, tick,
+	)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -168,38 +168,38 @@ read without the private key stored in the OS keychain on the originating device
 ## Restoring on a new machine
 
 1. Install enclaude.
-2. Clone this repository to {T}~/.enclaude/{T}:
-   {T}git clone <remote-url> ~/.enclaude{T}
+2. Clone this repository to {TICK}~/.enclaude/{TICK}:
+	{TICK}git clone <remote-url> ~/.enclaude{TICK}
 3. Import your private key into the keychain:
-   {T}enclaude key import{T}
+	{TICK}enclaude key import{TICK}
 4. Decrypt and restore your Claude files:
-   {T}enclaude unseal{T}
+	{TICK}enclaude unseal{TICK}
 
 ## Key recovery
 
 If the OS keychain entry is lost, restore from the passphrase-encrypted backup:
 
-{F}
+{FENCE}
 enclaude key recover key.age.backup
-{F}
+{FENCE}
 
-You will be prompted for the passphrase you set during {T}enclaude init{T}.
+You will be prompted for the passphrase you set during {TICK}enclaude init{TICK}.
 
 ## Daily use
 
-{F}
+{FENCE}
 enclaude seal          # encrypt and commit changes
 enclaude push          # push to remote
 enclaude pull          # pull and decrypt latest
 enclaude status        # show unsealed changes not yet sealed
-{F}
+{FENCE}
 `
 
 func buildReadme(publicKey, deviceID string) string {
 	return strings.NewReplacer(
 		"{PUBLIC_KEY}", publicKey,
 		"{DEVICE_ID}", deviceID,
-		"{T}", "`",
-		"{F}", "```",
+		"{TICK}", "`",
+		"{FENCE}", "```",
 	).Replace(readmeTemplate)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -169,11 +169,11 @@ read without the private key stored in the OS keychain on the originating device
 
 1. Install enclaude.
 2. Clone this repository to {TICK}~/.enclaude/{TICK}:
-	{TICK}git clone <remote-url> ~/.enclaude{TICK}
+   {TICK}git clone <remote-url> ~/.enclaude{TICK}
 3. Import your private key into the keychain:
-	{TICK}enclaude key import{TICK}
+   {TICK}enclaude key import{TICK}
 4. Decrypt and restore your Claude files:
-	{TICK}enclaude unseal{TICK}
+   {TICK}enclaude unseal{TICK}
 
 ## Key recovery
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildReadme(t *testing.T) {
+	tests := []struct {
+		name      string
+		publicKey string
+		deviceID  string
+		contains  []string
+		absent    []string
+	}{
+		{
+			name:      "contains public key and device ID",
+			publicKey: "age1testpublickey",
+			deviceID:  "myhost-deadbeef",
+			contains: []string{
+				"age1testpublickey",
+				"myhost-deadbeef",
+			},
+		},
+		{
+			name:      "no unresolved placeholders",
+			publicKey: "age1abc",
+			deviceID:  "host-1234",
+			absent: []string{
+				"{PUBLIC_KEY}",
+				"{DEVICE_ID}",
+				"{T}",
+				"{F}",
+			},
+		},
+		{
+			name:      "contains required sections",
+			publicKey: "age1abc",
+			deviceID:  "host-1234",
+			contains: []string{
+				"## Restoring on a new machine",
+				"## Key recovery",
+				"## Daily use",
+				"enclaude unseal",
+				"enclaude seal",
+				"Private keys are never stored here",
+			},
+		},
+		{
+			name:      "backticks and fences rendered correctly",
+			publicKey: "age1abc",
+			deviceID:  "host-1234",
+			contains: []string{
+				"`enclaude unseal`",
+				"```",
+			},
+			absent: []string{
+				"{T}",
+				"{F}",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildReadme(tt.publicKey, tt.deviceID)
+			for _, s := range tt.contains {
+				if !strings.Contains(got, s) {
+					t.Errorf("expected README to contain %q", s)
+				}
+			}
+			for _, s := range tt.absent {
+				if strings.Contains(got, s) {
+					t.Errorf("expected README NOT to contain %q", s)
+				}
+			}
+		})
+	}
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -29,8 +29,8 @@ func TestBuildReadme(t *testing.T) {
 			absent: []string{
 				"{PUBLIC_KEY}",
 				"{DEVICE_ID}",
-				"{T}",
-				"{F}",
+				"{TICK}",
+				"{FENCE}",
 			},
 		},
 		{
@@ -55,8 +55,8 @@ func TestBuildReadme(t *testing.T) {
 				"```",
 			},
 			absent: []string{
-				"{T}",
-				"{F}",
+				"{TICK}",
+				"{FENCE}",
 			},
 		},
 	}

--- a/cmd/readme_regen.go
+++ b/cmd/readme_regen.go
@@ -54,11 +54,15 @@ func runReadmeRegen(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("git add: %w", err)
 	}
 
-	gitCommit := exec.Command("git", "-C", sealDir, "commit", "-m", "seal: regenerate README.md")
-	if flagVerbose {
-		gitCommit.Stdout = cmd.OutOrStdout()
-		gitCommit.Stderr = cmd.ErrOrStderr()
+	// Skip commit if nothing changed.
+	if err := exec.Command("git", "-C", sealDir, "diff", "--quiet", "--cached", "README.md").Run(); err == nil {
+		fmt.Println("README.md unchanged, nothing to commit.")
+		return nil
 	}
+
+	gitCommit := exec.Command("git", "-C", sealDir, "commit", "-m", "seal: regenerate README.md")
+	gitCommit.Stdout = cmd.OutOrStdout()
+	gitCommit.Stderr = cmd.ErrOrStderr()
 	if err := gitCommit.Run(); err != nil {
 		return fmt.Errorf("git commit: %w", err)
 	}

--- a/cmd/readme_regen.go
+++ b/cmd/readme_regen.go
@@ -49,24 +49,36 @@ func runReadmeRegen(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Println("Wrote README.md")
 
-	gitAdd := exec.Command("git", "-C", sealDir, "add", "README.md")
-	if err := gitAdd.Run(); err != nil {
-		return fmt.Errorf("git add: %w", err)
+	committed, err := stageAndCommitReadme(cmd, sealDir)
+	if err != nil {
+		return err
 	}
-
-	// Skip commit if nothing changed.
-	if err := exec.Command("git", "-C", sealDir, "diff", "--quiet", "--cached", "README.md").Run(); err == nil {
+	if !committed {
 		fmt.Println("README.md unchanged, nothing to commit.")
 		return nil
-	}
-
-	gitCommit := exec.Command("git", "-C", sealDir, "commit", "-m", "seal: regenerate README.md")
-	gitCommit.Stdout = cmd.OutOrStdout()
-	gitCommit.Stderr = cmd.ErrOrStderr()
-	if err := gitCommit.Run(); err != nil {
-		return fmt.Errorf("git commit: %w", err)
 	}
 	fmt.Println("Committed README.md")
 
 	return nil
+}
+
+func stageAndCommitReadme(cmd *cobra.Command, sealDir string) (bool, error) {
+	gitAdd := exec.Command("git", "-C", sealDir, "add", "README.md")
+	if err := gitAdd.Run(); err != nil {
+		return false, fmt.Errorf("git add: %w", err)
+	}
+
+	// Skip commit if nothing changed.
+	if err := exec.Command("git", "-C", sealDir, "diff", "--quiet", "--cached", "README.md").Run(); err == nil {
+		return false, nil
+	}
+
+	gitCommit := exec.Command("git", "-C", sealDir, "commit", "--only", "-m", "seal: regenerate README.md", "README.md")
+	gitCommit.Stdout = cmd.OutOrStdout()
+	gitCommit.Stderr = cmd.ErrOrStderr()
+	if err := gitCommit.Run(); err != nil {
+		return false, fmt.Errorf("git commit: %w", err)
+	}
+
+	return true, nil
 }

--- a/cmd/readme_regen.go
+++ b/cmd/readme_regen.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/coredipper/enclaude/internal/config"
+	"github.com/coredipper/enclaude/internal/crypto"
+	"github.com/spf13/cobra"
+)
+
+var readmeRegenCmd = &cobra.Command{
+	Use:   "readme-regen",
+	Short: "Regenerate README.md in the seal store",
+	Long:  "Regenerate and commit README.md in an existing seal store.",
+	RunE:  runReadmeRegen,
+}
+
+func init() {
+	rootCmd.AddCommand(readmeRegenCmd)
+}
+
+func runReadmeRegen(cmd *cobra.Command, args []string) error {
+	sealDir := getSealDir()
+
+	if _, err := os.Stat(filepath.Join(sealDir, "seal.toml")); os.IsNotExist(err) {
+		return fmt.Errorf("no seal store found at %s — run enclaude init first", sealDir)
+	}
+
+	cfg, err := config.Load(sealDir)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	recipient, source, err := crypto.LoadPublicKey()
+	if err != nil {
+		return fmt.Errorf("loading key: %w", err)
+	}
+	if flagVerbose {
+		fmt.Printf("Using key from %s\n", source)
+	}
+
+	readme := buildReadme(recipient.String(), cfg.Seal.DeviceID)
+	readmePath := filepath.Join(sealDir, "README.md")
+	if err := os.WriteFile(readmePath, []byte(readme), 0644); err != nil {
+		return fmt.Errorf("writing README: %w", err)
+	}
+	fmt.Println("Wrote README.md")
+
+	gitAdd := exec.Command("git", "-C", sealDir, "add", "README.md")
+	if err := gitAdd.Run(); err != nil {
+		return fmt.Errorf("git add: %w", err)
+	}
+
+	gitCommit := exec.Command("git", "-C", sealDir, "commit", "-m", "seal: regenerate README.md")
+	if flagVerbose {
+		gitCommit.Stdout = cmd.OutOrStdout()
+		gitCommit.Stderr = cmd.ErrOrStderr()
+	}
+	if err := gitCommit.Run(); err != nil {
+		return fmt.Errorf("git commit: %w", err)
+	}
+	fmt.Println("Committed README.md")
+
+	return nil
+}

--- a/cmd/readme_regen_test.go
+++ b/cmd/readme_regen_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestReadmeRegenCommitDoesNotCaptureOtherStagedFiles(t *testing.T) {
+	repoDir := t.TempDir()
+	readmePath := filepath.Join(repoDir, "README.md")
+	notesPath := filepath.Join(repoDir, "notes.txt")
+
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.name", "Test User")
+	runGit(t, repoDir, "config", "user.email", "test@example.com")
+
+	writeTestFile(t, readmePath, "old readme\n")
+	writeTestFile(t, notesPath, "tracked notes\n")
+	runGit(t, repoDir, "add", "README.md", "notes.txt")
+	runGit(t, repoDir, "commit", "-m", "initial")
+
+	writeTestFile(t, readmePath, "new readme\n")
+	writeTestFile(t, notesPath, "manually staged change\n")
+	runGit(t, repoDir, "add", "notes.txt")
+
+	cmd := &cobra.Command{}
+	committed, err := stageAndCommitReadme(cmd, repoDir)
+	if err != nil {
+		t.Fatalf("stageAndCommitReadme() error = %v", err)
+	}
+	if !committed {
+		t.Fatal("expected README.md change to be committed")
+	}
+
+	committedFiles := strings.Fields(runGit(t, repoDir, "show", "--pretty=", "--name-only", "HEAD"))
+	if len(committedFiles) != 1 || committedFiles[0] != "README.md" {
+		t.Fatalf("expected README-only commit, got %v", committedFiles)
+	}
+
+	stagedFiles := strings.Fields(runGit(t, repoDir, "diff", "--cached", "--name-only"))
+	if len(stagedFiles) != 1 || stagedFiles[0] != "notes.txt" {
+		t.Fatalf("expected notes.txt to remain staged, got %v", stagedFiles)
+	}
+
+	if got := runGit(t, repoDir, "show", "HEAD:README.md"); got != "new readme\n" {
+		t.Fatalf("expected committed README contents to match, got %q", got)
+	}
+	if got := runGit(t, repoDir, "show", "HEAD:notes.txt"); got != "tracked notes\n" {
+		t.Fatalf("expected unrelated file to stay out of commit, got %q", got)
+	}
+}
+func runGit(t *testing.T, repoDir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", repoDir}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}
+
+func writeTestFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

  - `enclaude init` now generates a `README.md` in the seal repo as
  part of the initial commit, including the public key, device ID, restore
  instructions, key recovery steps, and a daily-use command reference
  - New `enclaude readme-regen` command regenerates and commits
  `README.md` for existing seal stores

## Test plan

  - [ ] Run `enclaude init` and confirm `README.md` is present in the
  seal repo with the correct public key and device ID
  - [ ] Confirm `README.md` is included in the initial commit
  - [ ] On an existing seal store, run `enclaude readme-regen` and
  confirm `README.md` is written and committed
  - [ ] Run `enclaude readme-regen` with no seal store present and
  confirm it errors with a clear message


## Sample README.md:

# enclaude seal store

     This repository contains an encrypted backup of a Claude Code
      configuration
     directory, managed by
     [enclaude](https://github.com/coredipper/enclaude).

     All files are encrypted with
     [age](https://age-encryption.org/) and cannot be
     read without the private key stored in the OS keychain on the
      originating device.

     > **Private keys are never stored here.** The age private key
      lives exclusively
     > in the OS keychain (and optionally in an encrypted backup
     file). Do not commit
     > private keys or unencrypted backups to this repository.

     ## Repository details

     | Field      | Value                    |
     |------------|---------------------------|
     | Public key | agefoo |
     | Device ID  | macbook-pro-a1b2c3d4 |

     ## Restoring on a new machine

     1. Install enclaude.
     2. Clone this repository to `~/.enclaude/`:
        `git clone <remote-url> ~/.enclaude`
     3. Import your private key into the keychain:
        `enclaude key import`
     4. Decrypt and restore your Claude files:
        `enclaude unseal`

     ## Key recovery

     If the OS keychain entry is lost, restore from the
     passphrase-encrypted backup:

     ```
     enclaude key recover key.age.backup
     ```

     You will be prompted for the passphrase you set during
     `enclaude init`.

     ## Daily use

     ```
     enclaude seal          # encrypt and commit changes
     enclaude push          # push to remote
     enclaude pull          # pull and decrypt latest
     enclaude status        # show unsealed changes not yet sealed