### PR TITLE
feat: Implement Linux key support 

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +10,7 @@ import (
 	"github.com/coredipper/enclaude/internal/config"
 	"github.com/coredipper/enclaude/internal/crypto"
 	"github.com/coredipper/enclaude/internal/store"
+	"github.com/coredipper/enclaude/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -51,12 +51,19 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("  Public key: %s\n", identity.Recipient().String())
 
-	// 2. Store in OS keychain
-	fmt.Println("Storing private key in OS keychain...")
-	if err := crypto.StoreKey(identity); err != nil {
-		return fmt.Errorf("storing key in keychain: %w", err)
+	// 2. Store private key (OS keyring, or passphrase-encrypted file fallback)
+	fmt.Println("Storing private key...")
+	source, err := crypto.StoreKey(identity)
+	if err != nil {
+		return fmt.Errorf("storing key: %w", err)
 	}
-	fmt.Println("  Stored in keychain.")
+	switch source {
+	case crypto.SourceKeyring:
+		fmt.Println("  Stored in OS keyring.")
+	case crypto.SourceFile:
+		path, _ := crypto.KeyFilePath()
+		fmt.Printf("  Stored in encrypted key file: %s\n", path)
+	}
 
 	// 3. Create seal directory
 	if err := os.MkdirAll(sealDir, 0700); err != nil {
@@ -64,10 +71,11 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	// 4. Create passphrase-encrypted backup
-	fmt.Print("\nEnter backup passphrase (for key recovery): ")
-	reader := bufio.NewReader(os.Stdin)
-	passphrase, _ := reader.ReadString('\n')
-	passphrase = strings.TrimSpace(passphrase)
+	fmt.Println()
+	passphrase, err := ui.ReadPassphraseOptional("Enter backup passphrase (for key recovery, blank to skip): ")
+	if err != nil {
+		return fmt.Errorf("reading backup passphrase: %w", err)
+	}
 
 	if passphrase != "" {
 		backup, err := crypto.EncryptWithPassphrase([]byte(identity.String()), passphrase)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -160,11 +160,15 @@ This repository contains an encrypted backup of a Claude Code configuration
 directory, managed by [enclaude](https://github.com/coredipper/enclaude).
 
 All files are encrypted with [age](https://age-encryption.org/) and cannot be
-read without the private key stored in the OS keychain on the originating device.
+read without the private key. On the originating device the key is stored in
+the OS keyring (macOS Keychain, Windows Credential Manager, Linux Secret
+Service) or — on hosts without one, such as headless Linux — in a
+passphrase-encrypted key file under {TICK}$XDG_CONFIG_HOME/enclaude/{TICK}.
 
-> **Private keys are never stored here.** The age private key lives exclusively
-> in the OS keychain (and optionally in an encrypted backup file). Do not commit
-> private keys or unencrypted backups to this repository.
+> **Private keys are never stored here.** The age private key lives in the OS
+> keyring or a local passphrase-encrypted key file (plus, optionally, an
+> encrypted backup file inside this repository). Do not commit private keys or
+> unencrypted backups to this repository.
 
 ## Repository details
 
@@ -178,14 +182,16 @@ read without the private key stored in the OS keychain on the originating device
 1. Install enclaude.
 2. Clone this repository to {TICK}~/.enclaude/{TICK}:
    {TICK}git clone <remote-url> ~/.enclaude{TICK}
-3. Import your private key into the keychain:
+3. Import your private key (into the OS keyring if available, otherwise into
+   a local passphrase-encrypted key file):
    {TICK}enclaude key import{TICK}
 4. Decrypt and restore your Claude files:
    {TICK}enclaude unseal{TICK}
 
 ## Key recovery
 
-If the OS keychain entry is lost, restore from the passphrase-encrypted backup:
+If both the OS keyring entry and the local key file are lost, restore from the
+passphrase-encrypted backup committed to this repository:
 
 {FENCE}
 enclaude key recover key.age.backup

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -7,13 +7,59 @@ import (
 	"path/filepath"
 	"strings"
 
+	"filippo.io/age"
 	"github.com/coredipper/enclaude/internal/config"
 	"github.com/coredipper/enclaude/internal/crypto"
 	"github.com/coredipper/enclaude/internal/gitops"
-	"github.com/coredipper/enclaude/internal/ui"
 	"github.com/coredipper/enclaude/internal/store"
+	"github.com/coredipper/enclaude/internal/ui"
 	"github.com/spf13/cobra"
 )
+
+// keyRotateDeps groups the side-effecting operations rotateKeyCore performs.
+// Injected so tests can verify ordering and failure semantics without touching
+// a real seal store, keyring, or filesystem.
+type keyRotateDeps struct {
+	loadKey  func() (*age.X25519Identity, error)
+	genKey   func() (*age.X25519Identity, error)
+	storeKey func(*age.X25519Identity) error
+	rotate   func(old *age.X25519Identity, newRecipient *age.X25519Recipient) (int, error)
+}
+
+// rotateKeyCore performs key rotation in the only safe order:
+//
+//  1. Load old key.
+//  2. Generate new key.
+//  3. Persist the new key.
+//  4. Re-encrypt all sealed objects to the new key.
+//
+// Persisting BEFORE re-encryption is critical: if storeKey prompts the user
+// (file fallback) and they cancel, or any other persistence failure occurs,
+// the seal store is still intact under the old key. Doing rotate first and
+// then storeKey would leave every object encrypted to a key that exists only
+// in process memory if storeKey fails — total data loss.
+func rotateKeyCore(d keyRotateDeps) (old, new *age.X25519Identity, rotated int, err error) {
+	old, err = d.loadKey()
+	if err != nil {
+		err = fmt.Errorf("loading current key: %w", err)
+		return
+	}
+	new, err = d.genKey()
+	if err != nil {
+		err = fmt.Errorf("generating new key: %w", err)
+		return
+	}
+	if err = d.storeKey(new); err != nil {
+		err = fmt.Errorf("storing new key (seal store untouched): %w", err)
+		return
+	}
+	rotated, err = d.rotate(old, new.Recipient())
+	if err != nil {
+		err = fmt.Errorf("rotation: %w", err)
+		return
+	}
+	return
+}
 
 var keyCmd = &cobra.Command{
 	Use:   "key",
@@ -123,30 +169,29 @@ var keyRotateCmd = &cobra.Command{
 			return err
 		}
 
-		oldIdentity, _, err := crypto.LoadKey()
+		deps := keyRotateDeps{
+			loadKey: func() (*age.X25519Identity, error) {
+				id, _, err := crypto.LoadKey()
+				return id, err
+			},
+			genKey: crypto.GenerateKey,
+			storeKey: func(id *age.X25519Identity) error {
+				_, err := crypto.StoreKey(id)
+				return err
+			},
+			rotate: func(old *age.X25519Identity, newRecipient *age.X25519Recipient) (int, error) {
+				fmt.Println("Re-encrypting all objects...")
+				return store.Rotate(cfg, old, newRecipient, flagVerbose, nil)
+			},
+		}
+
+		oldIdentity, newIdentity, rotated, err := rotateKeyCore(deps)
 		if err != nil {
-			return fmt.Errorf("loading current key: %w", err)
+			return err
 		}
 		oldPub := oldIdentity.Recipient().String()
-
-		fmt.Println("Generating new key...")
-		newIdentity, err := crypto.GenerateKey()
-		if err != nil {
-			return fmt.Errorf("generating new key: %w", err)
-		}
 		newPub := newIdentity.Recipient().String()
-
-		fmt.Println("Re-encrypting all objects...")
-		rotated, err := store.Rotate(cfg, oldIdentity, newIdentity.Recipient(), flagVerbose, nil)
-		if err != nil {
-			return fmt.Errorf("rotation: %w", err)
-		}
 		fmt.Printf("  Re-encrypted %d objects.\n", rotated)
-
-		// Store new key (replaces old) — keyring or file fallback
-		if _, err := crypto.StoreKey(newIdentity); err != nil {
-			return fmt.Errorf("storing new key: %w", err)
-		}
 
 		// Create new backup
 		fmt.Println()

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -69,10 +69,10 @@ var keyImportCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("reading key backup: %w", err)
 			}
-			fmt.Print("Backup passphrase: ")
-			reader := bufio.NewReader(os.Stdin)
-			passphrase, _ := reader.ReadString('\n')
-			passphrase = strings.TrimSpace(passphrase)
+			passphrase, err := ui.ReadPassphrase("Backup passphrase: ", false)
+			if err != nil {
+				return fmt.Errorf("reading passphrase: %w", err)
+			}
 
 			decrypted, err := crypto.DecryptWithPassphrase(encrypted, passphrase)
 			if err != nil {
@@ -101,11 +101,12 @@ var keyImportCmd = &cobra.Command{
 			return fmt.Errorf("invalid key: %w", err)
 		}
 
-		if err := crypto.StoreKey(identity); err != nil {
+		source, err := crypto.StoreKey(identity)
+		if err != nil {
 			return fmt.Errorf("storing key: %w", err)
 		}
 
-		fmt.Printf("%s Key imported.\n", ui.Green("OK"))
+		fmt.Printf("%s Key imported (stored in %s).\n", ui.Green("OK"), source)
 		fmt.Printf("Public key: %s\n", identity.Recipient().String())
 		return nil
 	},
@@ -142,16 +143,17 @@ var keyRotateCmd = &cobra.Command{
 		}
 		fmt.Printf("  Re-encrypted %d objects.\n", rotated)
 
-		// Store new key in keychain (replaces old)
-		if err := crypto.StoreKey(newIdentity); err != nil {
+		// Store new key (replaces old) — keyring or file fallback
+		if _, err := crypto.StoreKey(newIdentity); err != nil {
 			return fmt.Errorf("storing new key: %w", err)
 		}
 
 		// Create new backup
-		fmt.Print("\nNew backup passphrase (or Enter to skip): ")
-		reader := bufio.NewReader(os.Stdin)
-		passphrase, _ := reader.ReadString('\n')
-		passphrase = strings.TrimSpace(passphrase)
+		fmt.Println()
+		passphrase, err := ui.ReadPassphraseOptional("New backup passphrase (or Enter to skip): ")
+		if err != nil {
+			return fmt.Errorf("reading backup passphrase: %w", err)
+		}
 		if passphrase != "" {
 			backup, err := crypto.EncryptWithPassphrase([]byte(newIdentity.String()), passphrase)
 			if err != nil {

--- a/cmd/key_test.go
+++ b/cmd/key_test.go
@@ -1,0 +1,156 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"filippo.io/age"
+)
+
+// trace records the order of side-effects so tests can assert that storeKey
+// runs strictly before rotate, and that rotate is skipped when storeKey fails.
+type rotateTrace struct {
+	calls []string
+}
+
+func (t *rotateTrace) record(name string) { t.calls = append(t.calls, name) }
+
+func mustGen(t *testing.T) *age.X25519Identity {
+	t.Helper()
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("age.GenerateX25519Identity: %v", err)
+	}
+	return id
+}
+
+// TestRotateKeyCore_PersistsBeforeRotate verifies the happy-path ordering:
+// loadKey → genKey → storeKey → rotate. If storeKey ever runs after rotate,
+// a storeKey failure would leave the store re-encrypted to a key that was
+// never persisted (data loss).
+func TestRotateKeyCore_PersistsBeforeRotate(t *testing.T) {
+	tr := &rotateTrace{}
+	oldID := mustGen(t)
+	newID := mustGen(t)
+
+	deps := keyRotateDeps{
+		loadKey: func() (*age.X25519Identity, error) {
+			tr.record("loadKey")
+			return oldID, nil
+		},
+		genKey: func() (*age.X25519Identity, error) {
+			tr.record("genKey")
+			return newID, nil
+		},
+		storeKey: func(id *age.X25519Identity) error {
+			tr.record("storeKey")
+			if id != newID {
+				t.Fatalf("storeKey called with wrong identity")
+			}
+			return nil
+		},
+		rotate: func(old *age.X25519Identity, newR *age.X25519Recipient) (int, error) {
+			tr.record("rotate")
+			if old != oldID {
+				t.Fatal("rotate called with wrong old identity")
+			}
+			if newR.String() != newID.Recipient().String() {
+				t.Fatal("rotate called with wrong new recipient")
+			}
+			return 7, nil
+		},
+	}
+
+	gotOld, gotNew, n, err := rotateKeyCore(deps)
+	if err != nil {
+		t.Fatalf("rotateKeyCore: %v", err)
+	}
+	if gotOld != oldID || gotNew != newID || n != 7 {
+		t.Fatalf("unexpected return values: old=%v new=%v n=%d", gotOld, gotNew, n)
+	}
+
+	want := []string{"loadKey", "genKey", "storeKey", "rotate"}
+	if len(tr.calls) != len(want) {
+		t.Fatalf("call sequence = %v, want %v", tr.calls, want)
+	}
+	for i, c := range want {
+		if tr.calls[i] != c {
+			t.Fatalf("call[%d] = %q, want %q (full: %v)", i, tr.calls[i], c, tr.calls)
+		}
+	}
+}
+
+// TestRotateKeyCore_StoreFailureSkipsRotate is the regression guard for the
+// reported total-loss bug: when storeKey fails (e.g. user cancels passphrase
+// prompt on file-fallback hosts), rotate must NOT be called — otherwise the
+// seal store would be re-encrypted to a key that was never persisted.
+func TestRotateKeyCore_StoreFailureSkipsRotate(t *testing.T) {
+	tr := &rotateTrace{}
+	storeErr := errors.New("user cancelled passphrase prompt")
+
+	deps := keyRotateDeps{
+		loadKey: func() (*age.X25519Identity, error) {
+			tr.record("loadKey")
+			return mustGen(t), nil
+		},
+		genKey: func() (*age.X25519Identity, error) {
+			tr.record("genKey")
+			return mustGen(t), nil
+		},
+		storeKey: func(*age.X25519Identity) error {
+			tr.record("storeKey")
+			return storeErr
+		},
+		rotate: func(*age.X25519Identity, *age.X25519Recipient) (int, error) {
+			tr.record("rotate")
+			t.Fatal("rotate must not be called when storeKey fails")
+			return 0, nil
+		},
+	}
+
+	_, _, _, err := rotateKeyCore(deps)
+	if err == nil {
+		t.Fatal("expected error when storeKey fails")
+	}
+	if !errors.Is(err, storeErr) {
+		t.Fatalf("error chain missing storeErr: %v", err)
+	}
+
+	want := []string{"loadKey", "genKey", "storeKey"}
+	if len(tr.calls) != len(want) {
+		t.Fatalf("call sequence = %v, want %v (rotate must be absent)", tr.calls, want)
+	}
+}
+
+// TestRotateKeyCore_LoadFailureSkipsEverything is a sanity guard: if loadKey
+// fails there is nothing to rotate and no new key to persist.
+func TestRotateKeyCore_LoadFailureSkipsEverything(t *testing.T) {
+	tr := &rotateTrace{}
+	loadErr := errors.New("no key found")
+
+	deps := keyRotateDeps{
+		loadKey: func() (*age.X25519Identity, error) {
+			tr.record("loadKey")
+			return nil, loadErr
+		},
+		genKey: func() (*age.X25519Identity, error) {
+			tr.record("genKey")
+			return nil, nil
+		},
+		storeKey: func(*age.X25519Identity) error {
+			tr.record("storeKey")
+			return nil
+		},
+		rotate: func(*age.X25519Identity, *age.X25519Recipient) (int, error) {
+			tr.record("rotate")
+			return 0, nil
+		},
+	}
+
+	if _, _, _, err := rotateKeyCore(deps); err == nil {
+		t.Fatal("expected error when loadKey fails")
+	}
+	if len(tr.calls) != 1 || tr.calls[0] != "loadKey" {
+		t.Fatalf("call sequence = %v, want only [loadKey]", tr.calls)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/coredipper/enclaude/internal/crypto"
+	"github.com/coredipper/enclaude/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -33,6 +35,8 @@ func Execute() {
 }
 
 func init() {
+	crypto.DefaultPassphraseFunc = ui.ReadPassphrase
+
 	rootCmd.PersistentFlags().BoolVarP(&flagVerbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVar(&flagDryRun, "dry-run", false, "show what would happen without doing it")
 	rootCmd.PersistentFlags().StringVar(&flagClaudeDir, "claude-dir", "", "override ~/.claude/ location")

--- a/go.mod
+++ b/go.mod
@@ -3,24 +3,24 @@ module github.com/coredipper/enclaude
 go 1.26.1
 
 require (
-	filippo.io/age v1.3.1 // indirect
+	filippo.io/age v1.3.1
+	github.com/fatih/color v1.19.0
+	github.com/gofrs/flock v0.13.0
+	github.com/pelletier/go-toml/v2 v2.3.0
+	github.com/sergi/go-diff v1.4.0
+	github.com/spf13/cobra v1.10.2
+	github.com/zalando/go-keyring v0.2.8
+	golang.org/x/term v0.37.0
+)
+
+require (
 	filippo.io/hpke v0.4.0 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
-	github.com/fatih/color v1.19.0 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
-	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
-	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
-	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/schollz/progressbar/v3 v3.19.0 // indirect
-	github.com/sergi/go-diff v1.4.0 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	github.com/zalando/go-keyring v0.2.8 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/term v0.37.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd h1:ZLsPO6WdZ5zatV4UfVpr7oAwLGRZ+sebTUruuM4Ra3M=
+c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd/go.mod h1:SrHC2C7r5GkDk8R+NFVzYy/sdj0Ypg9htaPXQq5Cqeo=
 filippo.io/age v1.3.1 h1:hbzdQOJkuaMEpRCLSN1/C5DX74RPcNCk6oqhKMXmZi0=
 filippo.io/age v1.3.1/go.mod h1:EZorDTYUxt836i3zdori5IJX/v2Lj6kWFU0cfh6C0D4=
 filippo.io/hpke v0.4.0 h1:p575VVQ6ted4pL+it6M00V/f2qTZITO0zgmdKCkd5+A=
@@ -6,6 +8,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
@@ -22,16 +25,11 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
-github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/pelletier/go-toml/v2 v2.3.0 h1:k59bC/lIZREW0/iVaQR8nDHxVq8OVlIzYCOJf421CaM=
 github.com/pelletier/go-toml/v2 v2.3.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
-github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/schollz/progressbar/v3 v3.19.0 h1:Ea18xuIRQXLAUidVDox3AbwfUhD0/1IvohyTutOIFoc=
-github.com/schollz/progressbar/v3 v3.19.0/go.mod h1:IsO3lpbaGuzh8zIMzgY3+J8l4C8GjO0Y9S69eFvNsec=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
@@ -39,15 +37,17 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
 golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
-golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.37.0 h1:8EGAD0qCmHYZg6J17DvsMy9/wJ7/D/4pV/wfnld5lTU=
@@ -56,3 +56,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/crypto/keychain.go
+++ b/internal/crypto/keychain.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -14,39 +15,85 @@ const (
 	envKeyVar       = "ENCLAUDE_KEY"
 )
 
-// StoreKey saves the age private key to the OS keychain.
-func StoreKey(identity *age.X25519Identity) error {
-	return keyring.Set(keychainService, keychainAccount, identity.String())
+// Source identifiers returned by Load/Store operations.
+const (
+	SourceEnv     = "env"
+	SourceKeyring = "keyring"
+	SourceFile    = "file"
+)
+
+// PassphraseFunc prompts the user for a passphrase. When confirm is true the
+// implementation should prompt twice and verify the two inputs match.
+type PassphraseFunc func(prompt string, confirm bool) (string, error)
+
+// DefaultPassphraseFunc is consulted by StoreKey/LoadKey when the OS keyring
+// is unavailable and a passphrase is needed for the file fallback. The cmd
+// layer wires this to ui.ReadPassphrase at startup.
+var DefaultPassphraseFunc PassphraseFunc
+
+// StoreKey saves the age private key. It prefers the OS keyring; if the
+// keyring is unavailable (e.g. headless Linux without Secret Service), it
+// falls back to a passphrase-encrypted file under $XDG_CONFIG_HOME/enclaude.
+// Returns SourceKeyring or SourceFile indicating where the key was written.
+func StoreKey(identity *age.X25519Identity) (string, error) {
+	if err := keyring.Set(keychainService, keychainAccount, identity.String()); err == nil {
+		return SourceKeyring, nil
+	} else if DefaultPassphraseFunc == nil {
+		return "", fmt.Errorf("OS keyring unavailable and no passphrase prompter configured: %w", err)
+	}
+
+	pp, err := DefaultPassphraseFunc(
+		"OS keyring unavailable. Enter passphrase to encrypt key file: ", true)
+	if err != nil {
+		return "", fmt.Errorf("passphrase prompt: %w", err)
+	}
+	if err := StoreKeyFile(identity, pp); err != nil {
+		return "", err
+	}
+	return SourceFile, nil
 }
 
 // LoadKey retrieves the age private key, trying (in order):
-// 1. ENCLAUDE_KEY environment variable
-// 2. OS keychain
-// Returns the identity and the source it was loaded from.
+//  1. ENCLAUDE_KEY environment variable
+//  2. OS keyring
+//  3. passphrase-encrypted file fallback
 func LoadKey() (*age.X25519Identity, string, error) {
-	// Try environment variable first
 	if envKey := os.Getenv(envKeyVar); envKey != "" {
 		id, err := ParseIdentity(envKey)
 		if err != nil {
 			return nil, "", fmt.Errorf("parsing %s: %w", envKeyVar, err)
 		}
-		return id, "env", nil
+		return id, SourceEnv, nil
 	}
 
-	// Try OS keychain
-	secret, err := keyring.Get(keychainService, keychainAccount)
-	if err == nil {
+	if secret, err := keyring.Get(keychainService, keychainAccount); err == nil {
 		id, err := ParseIdentity(secret)
 		if err != nil {
-			return nil, "", fmt.Errorf("parsing keychain key: %w", err)
+			return nil, "", fmt.Errorf("parsing keyring key: %w", err)
 		}
-		return id, "keychain", nil
+		return id, SourceKeyring, nil
 	}
 
-	return nil, "", fmt.Errorf("no key found (checked %s env var and OS keychain)", envKeyVar)
+	if KeyFileExists() {
+		if DefaultPassphraseFunc == nil {
+			return nil, "", errors.New("encrypted key file present but no passphrase prompter configured")
+		}
+		pp, err := DefaultPassphraseFunc("Enter passphrase to unlock key file: ", false)
+		if err != nil {
+			return nil, "", fmt.Errorf("passphrase prompt: %w", err)
+		}
+		id, err := LoadKeyFile(pp)
+		if err != nil {
+			return nil, "", err
+		}
+		return id, SourceFile, nil
+	}
+
+	return nil, "", fmt.Errorf("no key found (checked %s env var, OS keyring, and %s)",
+		envKeyVar, mustKeyFilePath())
 }
 
-// LoadPublicKey loads just the public key (for encryption-only operations like seal).
+// LoadPublicKey loads just the public key (for encryption-only operations).
 func LoadPublicKey() (*age.X25519Recipient, string, error) {
 	id, source, err := LoadKey()
 	if err != nil {
@@ -55,7 +102,31 @@ func LoadPublicKey() (*age.X25519Recipient, string, error) {
 	return id.Recipient(), source, nil
 }
 
-// DeleteKey removes the age private key from the OS keychain.
+// DeleteKey removes the age private key from both the OS keyring and the
+// file fallback. Missing entries in either backend are ignored.
 func DeleteKey() error {
-	return keyring.Delete(keychainService, keychainAccount)
+	kErr := keyring.Delete(keychainService, keychainAccount)
+	if errors.Is(kErr, keyring.ErrNotFound) {
+		kErr = nil
+	}
+	fErr := DeleteKeyFile()
+
+	switch {
+	case kErr == nil && fErr == nil:
+		return nil
+	case kErr == nil:
+		return fErr
+	case fErr == nil:
+		return kErr
+	default:
+		return fmt.Errorf("keyring: %v; file: %v", kErr, fErr)
+	}
+}
+
+func mustKeyFilePath() string {
+	p, err := KeyFilePath()
+	if err != nil {
+		return "key file"
+	}
+	return p
 }

--- a/internal/crypto/keychain.go
+++ b/internal/crypto/keychain.go
@@ -63,7 +63,8 @@ func StoreKey(identity *age.X25519Identity) (string, error) {
 	// while the new key sits in the file, silently breaking decryption.
 	if delErr := keyringDelete(keychainService, keychainAccount); delErr != nil &&
 		!errors.Is(delErr, keyring.ErrNotFound) {
-		return "", fmt.Errorf("keyring write failed and stale entry could not be cleared (set=%v, delete=%v); aborting to avoid stale-key shadow", setErr, delErr)
+		return "", fmt.Errorf("keyring write failed and stale entry could not be cleared; aborting to avoid stale-key shadow: %w",
+			errors.Join(setErr, delErr))
 	}
 
 	pp, err := DefaultPassphraseFunc(
@@ -154,7 +155,10 @@ func DeleteKey() error {
 	case fErr == nil:
 		return kErr
 	default:
-		return fmt.Errorf("keyring: %v; file: %v", kErr, fErr)
+		return errors.Join(
+			fmt.Errorf("keyring: %w", kErr),
+			fmt.Errorf("file: %w", fErr),
+		)
 	}
 }
 

--- a/internal/crypto/keychain.go
+++ b/internal/crypto/keychain.go
@@ -46,11 +46,16 @@ var DefaultPassphraseFunc PassphraseFunc
 func StoreKey(identity *age.X25519Identity) (string, error) {
 	setErr := keyringSet(keychainService, keychainAccount, identity.String())
 	if setErr == nil {
-		// Keyring now authoritative. Drop any stale file fallback so it
-		// cannot shadow this entry on a future LoadKey if the keyring
-		// later goes missing.
+		// Keyring now authoritative. Try to drop any stale file fallback
+		// so it cannot shadow this entry on a future LoadKey if the
+		// keyring later goes missing. Cleanup failure is non-fatal:
+		// LoadKey precedence (env → keyring → file) means the fresh
+		// keyring entry is what callers will see, and the stale file is
+		// harmless until that changes. Surface as a warning instead of
+		// failing a successful write.
 		if err := DeleteKeyFile(); err != nil {
-			return "", fmt.Errorf("keyring write succeeded but failed to clear stale key file: %w", err)
+			fmt.Fprintf(os.Stderr,
+				"warning: keyring write succeeded but failed to clear stale key file: %v\n", err)
 		}
 		return SourceKeyring, nil
 	}

--- a/internal/crypto/keychain.go
+++ b/internal/crypto/keychain.go
@@ -26,6 +26,14 @@ const (
 // implementation should prompt twice and verify the two inputs match.
 type PassphraseFunc func(prompt string, confirm bool) (string, error)
 
+// Indirection so tests can simulate transient keyring failures (D-Bus blip,
+// locked keyring) independently of go-keyring's global error mock.
+var (
+	keyringSet    = keyring.Set
+	keyringGet    = keyring.Get
+	keyringDelete = keyring.Delete
+)
+
 // DefaultPassphraseFunc is consulted by StoreKey/LoadKey when the OS keyring
 // is unavailable and a passphrase is needed for the file fallback. The cmd
 // layer wires this to ui.ReadPassphrase at startup.
@@ -36,10 +44,26 @@ var DefaultPassphraseFunc PassphraseFunc
 // falls back to a passphrase-encrypted file under $XDG_CONFIG_HOME/enclaude.
 // Returns SourceKeyring or SourceFile indicating where the key was written.
 func StoreKey(identity *age.X25519Identity) (string, error) {
-	if err := keyring.Set(keychainService, keychainAccount, identity.String()); err == nil {
+	setErr := keyringSet(keychainService, keychainAccount, identity.String())
+	if setErr == nil {
+		// Keyring now authoritative. Drop any stale file fallback so it
+		// cannot shadow this entry on a future LoadKey if the keyring
+		// later goes missing.
+		if err := DeleteKeyFile(); err != nil {
+			return "", fmt.Errorf("keyring write succeeded but failed to clear stale key file: %w", err)
+		}
 		return SourceKeyring, nil
-	} else if DefaultPassphraseFunc == nil {
-		return "", fmt.Errorf("OS keyring unavailable and no passphrase prompter configured: %w", err)
+	}
+	if DefaultPassphraseFunc == nil {
+		return "", fmt.Errorf("OS keyring unavailable and no passphrase prompter configured: %w", setErr)
+	}
+
+	// Keyring write failed → file fallback. First wipe any stale keyring
+	// entry; otherwise LoadKey (env → keyring → file) returns the OLD key
+	// while the new key sits in the file, silently breaking decryption.
+	if delErr := keyringDelete(keychainService, keychainAccount); delErr != nil &&
+		!errors.Is(delErr, keyring.ErrNotFound) {
+		return "", fmt.Errorf("keyring write failed and stale entry could not be cleared (set=%v, delete=%v); aborting to avoid stale-key shadow", setErr, delErr)
 	}
 
 	pp, err := DefaultPassphraseFunc(
@@ -66,7 +90,7 @@ func LoadKey() (*age.X25519Identity, string, error) {
 		return id, SourceEnv, nil
 	}
 
-	if secret, err := keyring.Get(keychainService, keychainAccount); err == nil {
+	if secret, err := keyringGet(keychainService, keychainAccount); err == nil {
 		id, err := ParseIdentity(secret)
 		if err != nil {
 			return nil, "", fmt.Errorf("parsing keyring key: %w", err)
@@ -105,7 +129,7 @@ func LoadPublicKey() (*age.X25519Recipient, string, error) {
 // DeleteKey removes the age private key from both the OS keyring and the
 // file fallback. Missing entries in either backend are ignored.
 func DeleteKey() error {
-	kErr := keyring.Delete(keychainService, keychainAccount)
+	kErr := keyringDelete(keychainService, keychainAccount)
 	if errors.Is(kErr, keyring.ErrNotFound) {
 		kErr = nil
 	}

--- a/internal/crypto/keychain.go
+++ b/internal/crypto/keychain.go
@@ -127,12 +127,23 @@ func LoadPublicKey() (*age.X25519Recipient, string, error) {
 }
 
 // DeleteKey removes the age private key from both the OS keyring and the
-// file fallback. Missing entries in either backend are ignored.
+// file fallback. Missing entries in either backend are ignored, including
+// the case where the keyring backend itself is unavailable (headless Linux
+// without Secret Service) — there is nothing to delete there, so the file
+// fallback alone determines success.
 func DeleteKey() error {
-	kErr := keyringDelete(keychainService, keychainAccount)
-	if errors.Is(kErr, keyring.ErrNotFound) {
-		kErr = nil
+	var kErr error
+	// Probe the keyring first. Any error from Get (ErrNotFound or backend
+	// unavailable) means there is nothing for us to delete; skip Delete to
+	// avoid surfacing a backend-unavailable error on hosts where the file
+	// is the only real backend.
+	if _, getErr := keyringGet(keychainService, keychainAccount); getErr == nil {
+		if err := keyringDelete(keychainService, keychainAccount); err != nil &&
+			!errors.Is(err, keyring.ErrNotFound) {
+			kErr = err
+		}
 	}
+
 	fErr := DeleteKeyFile()
 
 	switch {

--- a/internal/crypto/keychain_test.go
+++ b/internal/crypto/keychain_test.go
@@ -199,6 +199,27 @@ func TestDeleteKey_RealKeyringErrorStillSurfaces(t *testing.T) {
 // chain on the abort path. Both underlying errors must be reachable via
 // errors.Is so callers and log scrapers can act on the specific failure mode
 // (e.g. retry on transient D-Bus errors but not on permanent auth errors).
+func TestStoreKey_FallbackAbortError_UnwrapsSetAndDeleteErrors(t *testing.T) {
+	withTestEnv(t)
+
+	setErr := errors.New("simulated dbus blip")
+	delErr := errors.New("simulated delete blip")
+	keyringSet = func(service, user, pass string) error { return setErr }
+	keyringDelete = func(service, user string) error { return delErr }
+
+	id, _ := GenerateKey()
+	if _, err := StoreKey(id); err == nil {
+		t.Fatal("expected StoreKey to abort with combined error")
+	} else {
+		if !errors.Is(err, setErr) {
+			t.Fatalf("error chain missing setErr (%v): %v", setErr, err)
+		}
+		if !errors.Is(err, delErr) {
+			t.Fatalf("error chain missing delErr (%v): %v", delErr, err)
+		}
+	}
+}
+
 // TestStoreKey_KeyringSuccess_FileCleanupFailureIsWarning verifies that a
 // failure to delete the stale fallback file after a successful keyring write
 // does not fail StoreKey. LoadKey precedence (keyring > file) keeps the
@@ -237,27 +258,6 @@ func TestStoreKey_KeyringSuccess_FileCleanupFailureIsWarning(t *testing.T) {
 	}
 	if secret != id.String() {
 		t.Fatal("keyring does not hold the stored key")
-	}
-}
-
-func TestStoreKey_FallbackAbortError_UnwrapsSetAndDeleteErrors(t *testing.T) {
-	withTestEnv(t)
-
-	setErr := errors.New("simulated dbus blip")
-	delErr := errors.New("simulated delete blip")
-	keyringSet = func(service, user, pass string) error { return setErr }
-	keyringDelete = func(service, user string) error { return delErr }
-
-	id, _ := GenerateKey()
-	if _, err := StoreKey(id); err == nil {
-		t.Fatal("expected StoreKey to abort with combined error")
-	} else {
-		if !errors.Is(err, setErr) {
-			t.Fatalf("error chain missing setErr (%v): %v", setErr, err)
-		}
-		if !errors.Is(err, delErr) {
-			t.Fatalf("error chain missing delErr (%v): %v", delErr, err)
-		}
 	}
 }
 

--- a/internal/crypto/keychain_test.go
+++ b/internal/crypto/keychain_test.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -191,6 +192,69 @@ func TestDeleteKey_RealKeyringErrorStillSurfaces(t *testing.T) {
 
 	if err := DeleteKey(); err == nil {
 		t.Fatal("expected error when keyring entry exists and Delete fails")
+	}
+}
+
+// TestStoreKey_FallbackAbortError_UnwrapsSetAndDeleteErrors guards the error
+// chain on the abort path. Both underlying errors must be reachable via
+// errors.Is so callers and log scrapers can act on the specific failure mode
+// (e.g. retry on transient D-Bus errors but not on permanent auth errors).
+func TestStoreKey_FallbackAbortError_UnwrapsSetAndDeleteErrors(t *testing.T) {
+	withTestEnv(t)
+
+	setErr := errors.New("simulated dbus blip")
+	delErr := errors.New("simulated delete blip")
+	keyringSet = func(service, user, pass string) error { return setErr }
+	keyringDelete = func(service, user string) error { return delErr }
+
+	id, _ := GenerateKey()
+	if _, err := StoreKey(id); err == nil {
+		t.Fatal("expected StoreKey to abort with combined error")
+	} else {
+		if !errors.Is(err, setErr) {
+			t.Fatalf("error chain missing setErr (%v): %v", setErr, err)
+		}
+		if !errors.Is(err, delErr) {
+			t.Fatalf("error chain missing delErr (%v): %v", delErr, err)
+		}
+	}
+}
+
+// TestDeleteKey_CombinedError_UnwrapsBothErrors guards the same property on
+// DeleteKey: when both backends fail, both underlying errors stay reachable.
+func TestDeleteKey_CombinedError_UnwrapsBothErrors(t *testing.T) {
+	withTestEnv(t)
+
+	// Force file-fallback delete to fail by pointing the path at a
+	// non-empty directory; os.Remove returns ENOTEMPTY (an *fs.PathError).
+	keyDir := t.TempDir()
+	badPath := filepath.Join(keyDir, "key.age.enc")
+	if err := os.Mkdir(badPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(badPath, "child"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write child: %v", err)
+	}
+	t.Setenv("ENCLAUDE_KEY_FILE", badPath)
+
+	// Seed keyring so DeleteKey actually attempts keyringDelete.
+	id, _ := GenerateKey()
+	if err := keyring.Set(keychainService, keychainAccount, id.String()); err != nil {
+		t.Fatalf("seed keyring: %v", err)
+	}
+	delErr := errors.New("keyring locked")
+	keyringDelete = func(service, user string) error { return delErr }
+
+	err := DeleteKey()
+	if err == nil {
+		t.Fatal("expected combined error from DeleteKey")
+	}
+	if !errors.Is(err, delErr) {
+		t.Fatalf("error chain missing keyring delErr: %v", err)
+	}
+	var pathErr *fs.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("error chain missing *fs.PathError for file delete: %v", err)
 	}
 }
 

--- a/internal/crypto/keychain_test.go
+++ b/internal/crypto/keychain_test.go
@@ -138,6 +138,62 @@ func TestStoreKey_KeyringSuccessClearsStaleFile(t *testing.T) {
 	}
 }
 
+// TestDeleteKey_FileOnlyHostIgnoresKeyringBackendError covers headless Linux:
+// keyring backend is unreachable (D-Bus error, not ErrNotFound), file is the
+// only real backend. DeleteKey must clear the file and return nil — the
+// keyring "missing entry" is whole-backend missing, semantically identical
+// to ErrNotFound for delete purposes.
+func TestDeleteKey_FileOnlyHostIgnoresKeyringBackendError(t *testing.T) {
+	withTestEnv(t)
+
+	// Simulate D-Bus / Secret Service unavailable. Anything that is not
+	// keyring.ErrNotFound exercises the regression path.
+	backendDown := errors.New("dbus: org.freedesktop.secrets not provided")
+	keyringGet = func(service, user string) (string, error) { return "", backendDown }
+
+	deleteCalled := false
+	keyringDelete = func(service, user string) error {
+		deleteCalled = true
+		return backendDown
+	}
+
+	// Seed file fallback (the only real backend on this host).
+	id, _ := GenerateKey()
+	if err := StoreKeyFile(id, "test-passphrase"); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	if err := DeleteKey(); err != nil {
+		t.Fatalf("DeleteKey returned error on file-only host: %v", err)
+	}
+	if KeyFileExists() {
+		t.Fatal("file fallback not deleted")
+	}
+	if deleteCalled {
+		t.Fatal("keyringDelete should not be called when Get reports backend unavailable")
+	}
+}
+
+// TestDeleteKey_RealKeyringErrorStillSurfaces ensures the relaxed contract
+// does not mask genuine failures: if the entry exists (Get succeeds) but
+// Delete fails, the error must propagate.
+func TestDeleteKey_RealKeyringErrorStillSurfaces(t *testing.T) {
+	withTestEnv(t)
+
+	id, _ := GenerateKey()
+	if err := keyring.Set(keychainService, keychainAccount, id.String()); err != nil {
+		t.Fatalf("seed keyring: %v", err)
+	}
+
+	keyringDelete = func(service, user string) error {
+		return errors.New("keyring locked")
+	}
+
+	if err := DeleteKey(); err == nil {
+		t.Fatal("expected error when keyring entry exists and Delete fails")
+	}
+}
+
 func TestLoadKey_NoKeySources(t *testing.T) {
 	withTestEnv(t)
 

--- a/internal/crypto/keychain_test.go
+++ b/internal/crypto/keychain_test.go
@@ -199,6 +199,47 @@ func TestDeleteKey_RealKeyringErrorStillSurfaces(t *testing.T) {
 // chain on the abort path. Both underlying errors must be reachable via
 // errors.Is so callers and log scrapers can act on the specific failure mode
 // (e.g. retry on transient D-Bus errors but not on permanent auth errors).
+// TestStoreKey_KeyringSuccess_FileCleanupFailureIsWarning verifies that a
+// failure to delete the stale fallback file after a successful keyring write
+// does not fail StoreKey. LoadKey precedence (keyring > file) keeps the
+// system consistent — the stale file is shadowed by the fresh keyring entry
+// and is harmless — so reporting a hard error after a successful write would
+// just confuse the user.
+func TestStoreKey_KeyringSuccess_FileCleanupFailureIsWarning(t *testing.T) {
+	withTestEnv(t)
+
+	// Point ENCLAUDE_KEY_FILE at a non-empty directory so DeleteKeyFile
+	// (os.Remove) returns ENOTEMPTY.
+	keyDir := t.TempDir()
+	badPath := filepath.Join(keyDir, "key.age.enc")
+	if err := os.Mkdir(badPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(badPath, "child"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write child: %v", err)
+	}
+	t.Setenv("ENCLAUDE_KEY_FILE", badPath)
+
+	id, _ := GenerateKey()
+	source, err := StoreKey(id)
+	if err != nil {
+		t.Fatalf("StoreKey should succeed despite stale-file cleanup failure: %v", err)
+	}
+	if source != SourceKeyring {
+		t.Fatalf("source = %q, want %q", source, SourceKeyring)
+	}
+
+	// Verify keyring actually holds the new key — confirms the failure
+	// happened during cleanup, not during the keyring write.
+	secret, gerr := keyring.Get(keychainService, keychainAccount)
+	if gerr != nil {
+		t.Fatalf("keyring lookup after StoreKey: %v", gerr)
+	}
+	if secret != id.String() {
+		t.Fatal("keyring does not hold the stored key")
+	}
+}
+
 func TestStoreKey_FallbackAbortError_UnwrapsSetAndDeleteErrors(t *testing.T) {
 	withTestEnv(t)
 

--- a/internal/crypto/keychain_test.go
+++ b/internal/crypto/keychain_test.go
@@ -1,0 +1,164 @@
+package crypto
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zalando/go-keyring"
+)
+
+// withTestEnv isolates each test: temp key file path, in-memory keyring mock,
+// stub passphrase prompter, restored keyring func vars on cleanup.
+func withTestEnv(t *testing.T) {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Setenv("ENCLAUDE_KEY_FILE", filepath.Join(dir, "key.age.enc"))
+	t.Setenv(envKeyVar, "")
+
+	keyring.MockInit()
+
+	origSet, origGet, origDel := keyringSet, keyringGet, keyringDelete
+	origPP := DefaultPassphraseFunc
+	t.Cleanup(func() {
+		keyringSet, keyringGet, keyringDelete = origSet, origGet, origDel
+		DefaultPassphraseFunc = origPP
+	})
+
+	DefaultPassphraseFunc = func(prompt string, confirm bool) (string, error) {
+		return "test-passphrase", nil
+	}
+}
+
+// TestStoreKey_FallbackClearsStaleKeyringEntry exercises the rotate scenario:
+// keyring already holds K_old, keyring.Set(K_new) fails (D-Bus blip), fallback
+// must wipe stale entry so LoadKey returns K_new from the file rather than the
+// stale K_old from the keyring.
+func TestStoreKey_FallbackClearsStaleKeyringEntry(t *testing.T) {
+	withTestEnv(t)
+
+	kOld, err := GenerateKey()
+	if err != nil {
+		t.Fatalf("generate K_old: %v", err)
+	}
+	if err := keyring.Set(keychainService, keychainAccount, kOld.String()); err != nil {
+		t.Fatalf("seed keyring with K_old: %v", err)
+	}
+
+	keyringSet = func(service, user, pass string) error {
+		return errors.New("simulated dbus blip")
+	}
+
+	kNew, err := GenerateKey()
+	if err != nil {
+		t.Fatalf("generate K_new: %v", err)
+	}
+
+	source, err := StoreKey(kNew)
+	if err != nil {
+		t.Fatalf("StoreKey returned error: %v", err)
+	}
+	if source != SourceFile {
+		t.Fatalf("expected SourceFile fallback, got %q", source)
+	}
+
+	// LoadKey precedence is env → keyring → file. The fallback path must
+	// have cleared the stale K_old keyring entry, otherwise LoadKey returns
+	// it before reaching the file.
+	got, src, err := LoadKey()
+	if err != nil {
+		t.Fatalf("LoadKey: %v", err)
+	}
+	if src != SourceFile {
+		t.Fatalf("LoadKey source = %q, want %q (keyring should be empty)", src, SourceFile)
+	}
+	if got.String() != kNew.String() {
+		t.Fatal("LoadKey returned stale K_old; fallback failed to clear keyring")
+	}
+}
+
+// TestStoreKey_FallbackAbortsWhenKeyringDeleteFails verifies StoreKey refuses
+// to write the file fallback when it cannot clear a stale keyring entry —
+// committing the file in that state would leave LoadKey returning the
+// shadowed stale key.
+func TestStoreKey_FallbackAbortsWhenKeyringDeleteFails(t *testing.T) {
+	withTestEnv(t)
+
+	kOld, _ := GenerateKey()
+	if err := keyring.Set(keychainService, keychainAccount, kOld.String()); err != nil {
+		t.Fatalf("seed keyring: %v", err)
+	}
+
+	keyringSet = func(service, user, pass string) error {
+		return errors.New("set blip")
+	}
+	keyringDelete = func(service, user string) error {
+		return errors.New("delete blip")
+	}
+
+	kNew, _ := GenerateKey()
+	source, err := StoreKey(kNew)
+	if err == nil {
+		t.Fatalf("StoreKey unexpectedly succeeded (source=%q); should refuse to commit half-state", source)
+	}
+
+	// Ensure no key file was written behind the user's back.
+	if KeyFileExists() {
+		t.Fatal("key file written despite StoreKey error; half-state committed")
+	}
+}
+
+// TestStoreKey_KeyringSuccessClearsStaleFile covers the inverse case: file
+// holds an old key from a prior fallback, then keyring becomes available and
+// StoreKey writes a new key to keyring. The stale file must be cleared so a
+// future keyring.Get failure does not return the obsolete file key.
+func TestStoreKey_KeyringSuccessClearsStaleFile(t *testing.T) {
+	withTestEnv(t)
+
+	kOld, _ := GenerateKey()
+	if err := StoreKeyFile(kOld, "test-passphrase"); err != nil {
+		t.Fatalf("seed file with K_old: %v", err)
+	}
+	if !KeyFileExists() {
+		t.Fatal("seed precondition: key file missing")
+	}
+
+	kNew, _ := GenerateKey()
+	source, err := StoreKey(kNew)
+	if err != nil {
+		t.Fatalf("StoreKey: %v", err)
+	}
+	if source != SourceKeyring {
+		t.Fatalf("expected SourceKeyring, got %q", source)
+	}
+	if KeyFileExists() {
+		t.Fatal("stale key file not cleared after keyring write succeeded")
+	}
+}
+
+func TestLoadKey_NoKeySources(t *testing.T) {
+	withTestEnv(t)
+
+	if _, _, err := LoadKey(); err == nil {
+		t.Fatal("expected error when no key in env, keyring, or file")
+	} else if !contains(err.Error(), "no key found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Sanity: file path used in error message points into temp dir.
+	want := os.Getenv("ENCLAUDE_KEY_FILE")
+	if want == "" {
+		t.Fatal("ENCLAUDE_KEY_FILE not set by test harness")
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/crypto/keyfile.go
+++ b/internal/crypto/keyfile.go
@@ -1,0 +1,93 @@
+package crypto
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"filippo.io/age"
+)
+
+const keyFileName = "key.age.enc"
+
+// KeyFilePath returns the path to the passphrase-encrypted key file used as a
+// fallback when the OS keyring is unavailable. Honors ENCLAUDE_KEY_FILE for an
+// explicit override, otherwise $XDG_CONFIG_HOME/enclaude/key.age.enc, falling
+// back to ~/.config/enclaude/key.age.enc.
+func KeyFilePath() (string, error) {
+	if override := os.Getenv("ENCLAUDE_KEY_FILE"); override != "" {
+		return override, nil
+	}
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("locating home directory: %w", err)
+		}
+		base = filepath.Join(home, ".config")
+	}
+	return filepath.Join(base, "enclaude", keyFileName), nil
+}
+
+// KeyFileExists reports whether the fallback key file is present.
+func KeyFileExists() bool {
+	p, err := KeyFilePath()
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(p)
+	return err == nil
+}
+
+// StoreKeyFile encrypts identity with passphrase (age scrypt) and writes it
+// to the fallback location with 0600 permissions.
+func StoreKeyFile(identity *age.X25519Identity, passphrase string) error {
+	if passphrase == "" {
+		return errors.New("passphrase required for file-based key storage")
+	}
+	encrypted, err := EncryptWithPassphrase([]byte(identity.String()), passphrase)
+	if err != nil {
+		return fmt.Errorf("encrypting key: %w", err)
+	}
+	p, err := KeyFilePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0700); err != nil {
+		return fmt.Errorf("creating key file directory: %w", err)
+	}
+	if err := os.WriteFile(p, encrypted, 0600); err != nil {
+		return fmt.Errorf("writing key file: %w", err)
+	}
+	return nil
+}
+
+// LoadKeyFile reads and decrypts the fallback key file.
+func LoadKeyFile(passphrase string) (*age.X25519Identity, error) {
+	p, err := KeyFilePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, fmt.Errorf("reading key file: %w", err)
+	}
+	plain, err := DecryptWithPassphrase(data, passphrase)
+	if err != nil {
+		return nil, fmt.Errorf("decrypting key file (wrong passphrase?): %w", err)
+	}
+	return ParseIdentity(string(plain))
+}
+
+// DeleteKeyFile removes the fallback key file. Missing file is not an error.
+func DeleteKeyFile() error {
+	p, err := KeyFilePath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -1,0 +1,60 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// ReadPassphrase reads a passphrase from the controlling terminal without
+// echo. When confirm is true it prompts a second time and verifies the two
+// inputs match (used when setting a new passphrase).
+func ReadPassphrase(prompt string, confirm bool) (string, error) {
+	fd := int(os.Stdin.Fd())
+	if !term.IsTerminal(fd) {
+		return "", fmt.Errorf("cannot prompt for passphrase: stdin is not a terminal")
+	}
+
+	fmt.Fprint(os.Stderr, prompt)
+	pw, err := term.ReadPassword(fd)
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return "", fmt.Errorf("reading passphrase: %w", err)
+	}
+	pp := strings.TrimSpace(string(pw))
+	if pp == "" {
+		return "", fmt.Errorf("empty passphrase")
+	}
+
+	if confirm {
+		fmt.Fprint(os.Stderr, "Confirm passphrase: ")
+		pw2, err := term.ReadPassword(fd)
+		fmt.Fprintln(os.Stderr)
+		if err != nil {
+			return "", fmt.Errorf("reading confirmation: %w", err)
+		}
+		if strings.TrimSpace(string(pw2)) != pp {
+			return "", fmt.Errorf("passphrases do not match")
+		}
+	}
+	return pp, nil
+}
+
+// ReadPassphraseOptional reads a passphrase without echo. Empty input is
+// returned as "" without error (caller treats as "skip"). Use for optional
+// backup-passphrase prompts.
+func ReadPassphraseOptional(prompt string) (string, error) {
+	fd := int(os.Stdin.Fd())
+	if !term.IsTerminal(fd) {
+		return "", fmt.Errorf("cannot prompt for passphrase: stdin is not a terminal")
+	}
+	fmt.Fprint(os.Stderr, prompt)
+	pw, err := term.ReadPassword(fd)
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return "", fmt.Errorf("reading passphrase: %w", err)
+	}
+	return strings.TrimSpace(string(pw)), nil
+}

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -8,6 +8,16 @@ import (
 	"golang.org/x/term"
 )
 
+// sanitizePassphrase preserves every byte the user typed. It strips only a
+// trailing CR/LF artifact that some terminal backends may include — it does
+// NOT trim other whitespace, since users can legitimately have leading,
+// trailing, or internal spaces/tabs in passphrases (especially when pasting
+// from a password manager). Anything more aggressive silently mangles
+// passphrases into "wrong passphrase?" decryption failures.
+func sanitizePassphrase(raw []byte) string {
+	return strings.TrimRight(string(raw), "\r\n")
+}
+
 // ReadPassphrase reads a passphrase from the controlling terminal without
 // echo. When confirm is true it prompts a second time and verifies the two
 // inputs match (used when setting a new passphrase).
@@ -23,7 +33,7 @@ func ReadPassphrase(prompt string, confirm bool) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("reading passphrase: %w", err)
 	}
-	pp := strings.TrimSpace(string(pw))
+	pp := sanitizePassphrase(pw)
 	if pp == "" {
 		return "", fmt.Errorf("empty passphrase")
 	}
@@ -35,7 +45,7 @@ func ReadPassphrase(prompt string, confirm bool) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("reading confirmation: %w", err)
 		}
-		if strings.TrimSpace(string(pw2)) != pp {
+		if sanitizePassphrase(pw2) != pp {
 			return "", fmt.Errorf("passphrases do not match")
 		}
 	}
@@ -56,5 +66,5 @@ func ReadPassphraseOptional(prompt string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("reading passphrase: %w", err)
 	}
-	return strings.TrimSpace(string(pw)), nil
+	return sanitizePassphrase(pw), nil
 }

--- a/internal/ui/prompt_test.go
+++ b/internal/ui/prompt_test.go
@@ -1,0 +1,74 @@
+package ui
+
+import "testing"
+
+// Passphrases must preserve every character the user actually typed, except
+// for a trailing CR/LF artifact that some terminal backends may include. Any
+// trimming beyond that silently mangles passphrases pasted from password
+// managers (which frequently include spaces, tabs, or unicode whitespace),
+// turning a correct passphrase into a "wrong passphrase?" decryption error.
+
+func TestSanitizePassphrase_PreservesInternalSpaces(t *testing.T) {
+	in := []byte("my long pass phrase")
+	if got := sanitizePassphrase(in); got != "my long pass phrase" {
+		t.Fatalf("got %q, want internal spaces preserved", got)
+	}
+}
+
+func TestSanitizePassphrase_PreservesLeadingSpaces(t *testing.T) {
+	in := []byte("   leading")
+	if got := sanitizePassphrase(in); got != "   leading" {
+		t.Fatalf("got %q, want leading spaces preserved", got)
+	}
+}
+
+func TestSanitizePassphrase_PreservesTrailingSpaces(t *testing.T) {
+	in := []byte("trailing   ")
+	if got := sanitizePassphrase(in); got != "trailing   " {
+		t.Fatalf("got %q, want trailing spaces preserved", got)
+	}
+}
+
+func TestSanitizePassphrase_PreservesTabs(t *testing.T) {
+	in := []byte("a\tb\tc")
+	if got := sanitizePassphrase(in); got != "a\tb\tc" {
+		t.Fatalf("got %q, want tabs preserved", got)
+	}
+}
+
+func TestSanitizePassphrase_StripsTrailingNewline(t *testing.T) {
+	in := []byte("pass\n")
+	if got := sanitizePassphrase(in); got != "pass" {
+		t.Fatalf("got %q, want %q", got, "pass")
+	}
+}
+
+func TestSanitizePassphrase_StripsTrailingCRLF(t *testing.T) {
+	in := []byte("pass\r\n")
+	if got := sanitizePassphrase(in); got != "pass" {
+		t.Fatalf("got %q, want %q", got, "pass")
+	}
+}
+
+func TestSanitizePassphrase_DoesNotStripTrailingNewlineFollowedByContent(t *testing.T) {
+	// Defensive: only trailing CR/LF stripped, not embedded.
+	in := []byte("a\nb")
+	if got := sanitizePassphrase(in); got != "a\nb" {
+		t.Fatalf("got %q, want embedded newline preserved", got)
+	}
+}
+
+func TestSanitizePassphrase_EmptyStaysEmpty(t *testing.T) {
+	if got := sanitizePassphrase(nil); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+	if got := sanitizePassphrase([]byte{}); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}
+
+func TestSanitizePassphrase_OnlyNewlineBecomesEmpty(t *testing.T) {
+	if got := sanitizePassphrase([]byte("\n")); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a passphrase-encrypted file fallback for the age private key so `enclaude init` works on Linux systems without an OS Secret Service (`gnome-keyring` / KWallet). Previously `init` aborted with a keyring error on headless boxes, WSL, minimal DEs, and SSH sessions.

Also fixes backup-passphrase prompts that were echoing input in cleartext — they now use `term.ReadPassword` like every other passphrase prompt.

## Motivation

`zalando/go-keyring` on Linux talks only to Secret Service over D-Bus. If no provider is running, `keyring.Set` fails and `enclaude init` cannot complete. Many Linux environments don't ship one by default, leaving users with no path forward short of installing and unlocking `gnome-keyring`.

## Approach

Keep the OS keyring as the preferred backend; fall back to a passphrase-encrypted file when the keyring is unavailable. Encryption uses the existing age scrypt path — no new crypto dependency.

**Storage precedence**

- `StoreKey`: OS keyring → encrypted file
- `LoadKey`: `ENCLAUDE_KEY` env → OS keyring → encrypted file

**Key file location** (first match wins)

1. `$ENCLAUDE_KEY_FILE` (explicit override)
2. `$XDG_CONFIG_HOME/enclaude/key.age.enc`
3. `~/.config/enclaude/key.age.enc`

File mode is `0600`; parent directory `0700`.

## Changes

- `internal/crypto/keyfile.go` *(new)* — `KeyFilePath`, `KeyFileExists`, `StoreKeyFile`, `LoadKeyFile`, `DeleteKeyFile`
- `internal/crypto/keychain.go` — keyring → file fallback chain; `StoreKey` now returns `(source, error)`; `DeleteKey` clears both backends; new `Source{Env,Keyring,File}` constants and `PassphraseFunc` callback type
- `internal/ui/prompt.go` *(new)* — `ReadPassphrase` (silent, optional confirm) and `ReadPassphraseOptional` (silent, empty = skip) using `golang.org/x/term`
- `cmd/root.go` — wires `crypto.DefaultPassphraseFunc = ui.ReadPassphrase`
- `cmd/init.go`, `cmd/key.go` — handle `StoreKey` source return; replace `bufio.ReadString` cleartext prompts (init backup, `key import --from-backup`, `key rotate` backup) with masked prompts

## Behavior

**With keyring available** (macOS / Windows / Linux + Secret Service): unchanged — key stored in the OS keyring, no extra prompts.

**Without keyring** (headless Linux / WSL / minimal DE):
- `init` prompts twice for a passphrase, writes `~/.config/enclaude/key.age.enc`, prints the path
- subsequent `seal` / `unseal` / `pull` prompt once for that passphrase
- automation can set `ENCLAUDE_KEY=AGE-SECRET-KEY-...` to skip prompts in hooks / cron

`StoreKey` and `LoadKey` retain their existing call sites; only the new `(source, error)` return on `StoreKey` required call-site updates (3 sites).

## Testing

- `go build ./...` — clean
- `go test ./...` — all packages pass
- Manual: `enclaude init` on this Linux box (no Secret Service) — keyring path failed, file fallback prompted, key file written at `~/.config/enclaude/key.age.enc`, initial seal completed
- Manual: backup passphrase entry in `init` — input no longer echoed

## Notes for reviewers

- `DefaultPassphraseFunc` is a package-level var rather than a parameter on every call site; this keeps `LoadKey()` / `LoadPublicKey()` / `DeleteKey()` signatures stable across the ~15 existing callers.
- `KeyFileExists` is checked before prompting on load so users without a fallback file see the original "no key found" error rather than a passphrase prompt that can't succeed.
- README template in `cmd/init.go` still says "private key lives exclusively in the OS keychain"; left alone to keep the diff focused — worth a follow-up to document the file fallback.

## Follow-ups (out of scope)

- Update generated seal-store README to describe the file backend
- Optional: cache decrypted key for the duration of a single `enclaude` invocation so multi-step commands (e.g. `seal` → `commit`) don't reprompt
