### PR TITLE
🔒 Fix command injection vulnerability in gitops Push, Fetch, Pull and Merge

### DIFF
--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -55,27 +55,27 @@ func (g *Git) HasChanges() bool {
 
 // Push pushes to the given remote and branch.
 func (g *Git) Push(remote, branch string) (string, error) {
-	return g.run("push", remote, branch)
+	return g.run("push", "--", remote, branch)
 }
 
 // PushWithUpstream pushes and sets upstream tracking.
 func (g *Git) PushWithUpstream(remote, branch string) (string, error) {
-	return g.run("push", "-u", remote, branch)
+	return g.run("push", "-u", "--", remote, branch)
 }
 
 // Fetch fetches from the given remote.
 func (g *Git) Fetch(remote string) (string, error) {
-	return g.run("fetch", remote)
+	return g.run("fetch", "--", remote)
 }
 
 // Pull pulls from the given remote and branch.
 func (g *Git) Pull(remote, branch string) (string, error) {
-	return g.run("pull", remote, branch)
+	return g.run("pull", "--", remote, branch)
 }
 
 // Merge merges the given ref into the current branch.
 func (g *Git) Merge(ref string) (string, error) {
-	return g.run("merge", ref)
+	return g.run("merge", "--", ref)
 }
 
 // MergeAbort aborts a merge in progress.


### PR DESCRIPTION
🎯 **What:** Fixed an argument/command injection vulnerability in `internal/gitops/git.go` by appending the `--` flag terminator before passing user-controlled variables. This affects the `PushWithUpstream`, `Push`, `Fetch`, `Pull`, and `Merge` functions.

⚠️ **Risk:** Without the `--` terminator, an attacker could supply a branch or remote name starting with `-` (e.g. `--receive-pack=touch /tmp/pwned`). The git executable would interpret this as an option flag instead of a positional argument, leading to arbitrary command execution or logic subversion during git operations. 

🛡️ **Solution:** Inserted the `--` argument into the `git` `exec.Command` invocations for functions accepting untrusted references or remotes, ensuring these arguments are strictly parsed as positional arguments by the git executable.

---
*PR created automatically by Jules for task [10916778368046979740](https://jules.google.com/task/10916778368046979740) started by @coredipper*