### PR TITLE
🧹 [Extract interactive backup prompt to simplify runInit]

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"filippo.io/age"
 	"github.com/coredipper/enclaude/internal/config"
 	"github.com/coredipper/enclaude/internal/crypto"
 	"github.com/coredipper/enclaude/internal/store"
@@ -71,24 +72,8 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	// 4. Create passphrase-encrypted backup
-	fmt.Println()
-	passphrase, err := ui.ReadPassphraseOptional("Enter backup passphrase (for key recovery, blank to skip): ")
-	if err != nil {
-		return fmt.Errorf("reading backup passphrase: %w", err)
-	}
-
-	if passphrase != "" {
-		backup, err := crypto.EncryptWithPassphrase([]byte(identity.String()), passphrase)
-		if err != nil {
-			return fmt.Errorf("creating key backup: %w", err)
-		}
-		backupPath := filepath.Join(sealDir, "key.age.backup")
-		if err := os.WriteFile(backupPath, backup, 0600); err != nil {
-			return fmt.Errorf("writing key backup: %w", err)
-		}
-		fmt.Println("  Key backup saved.")
-	} else {
-		fmt.Println("  Skipping backup (no passphrase entered).")
+	if err := createKeyBackup(sealDir, identity); err != nil {
+		return err
 	}
 
 	// 5. Write default config
@@ -208,6 +193,30 @@ enclaude pull          # pull and decrypt latest
 enclaude status        # show unsealed changes not yet sealed
 {FENCE}
 `
+
+func createKeyBackup(sealDir string, identity *age.X25519Identity) error {
+	fmt.Println()
+	passphrase, err := ui.ReadPassphraseOptional("Enter backup passphrase (for key recovery, blank to skip): ")
+	if err != nil {
+		return fmt.Errorf("reading backup passphrase: %w", err)
+	}
+
+	if passphrase != "" {
+		backup, err := crypto.EncryptWithPassphrase([]byte(identity.String()), passphrase)
+		if err != nil {
+			return fmt.Errorf("creating key backup: %w", err)
+		}
+		backupPath := filepath.Join(sealDir, "key.age.backup")
+		if err := os.WriteFile(backupPath, backup, 0600); err != nil {
+			return fmt.Errorf("writing key backup: %w", err)
+		}
+		fmt.Println("  Key backup saved.")
+	} else {
+		fmt.Println("  Skipping backup (no passphrase entered).")
+	}
+
+	return nil
+}
 
 func buildReadme(publicKey, deviceID string) string {
 	return strings.NewReplacer(

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"filippo.io/age"
 	"github.com/coredipper/enclaude/internal/config"
 	"github.com/coredipper/enclaude/internal/crypto"
 	"github.com/coredipper/enclaude/internal/store"
@@ -72,7 +71,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	// 4. Create passphrase-encrypted backup
-	if err := createKeyBackup(sealDir, identity); err != nil {
+	if err := createKeyBackup(sealDir, identity.String()); err != nil {
 		return err
 	}
 
@@ -194,7 +193,7 @@ enclaude status        # show unsealed changes not yet sealed
 {FENCE}
 `
 
-func createKeyBackup(sealDir string, identity *age.X25519Identity) error {
+func createKeyBackup(sealDir, secretKey string) error {
 	fmt.Println()
 	passphrase, err := ui.ReadPassphraseOptional("Enter backup passphrase (for key recovery, blank to skip): ")
 	if err != nil {
@@ -202,7 +201,7 @@ func createKeyBackup(sealDir string, identity *age.X25519Identity) error {
 	}
 
 	if passphrase != "" {
-		backup, err := crypto.EncryptWithPassphrase([]byte(identity.String()), passphrase)
+		backup, err := crypto.EncryptWithPassphrase([]byte(secretKey), passphrase)
 		if err != nil {
 			return fmt.Errorf("creating key backup: %w", err)
 		}


### PR DESCRIPTION
🎯 **What:** Extracted the interactive prompt logic for creating a passphrase-encrypted backup into a separate function `createKeyBackup`.
💡 **Why:** `runInit` in `cmd/init.go` was overly long and handled multiple disparate tasks. Extracting this specific logic simplifies the main function, making the code easier to read and maintain.
✅ **Verification:** Verified by checking functionality via `go test ./...` and `go build ./cmd`. The refactored code has identical behavior, and all existing tests pass.
✨ **Result:** Improved modularity and code health in `cmd/init.go`.

---
*PR created automatically by Jules for task [12522806710134204797](https://jules.google.com/task/12522806710134204797) started by @coredipper*