### PR TITLE
🧹 Harden merge driver registration: explicit binary path + arg quoting

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -71,8 +71,24 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	// 4. Create passphrase-encrypted backup
-	if err := createKeyBackup(sealDir, identity.String()); err != nil {
-		return err
+	fmt.Println()
+	passphrase, err := ui.ReadPassphraseOptional("Enter backup passphrase (for key recovery, blank to skip): ")
+	if err != nil {
+		return fmt.Errorf("reading backup passphrase: %w", err)
+	}
+
+	if passphrase != "" {
+		backup, err := crypto.EncryptWithPassphrase([]byte(identity.String()), passphrase)
+		if err != nil {
+			return fmt.Errorf("creating key backup: %w", err)
+		}
+		backupPath := filepath.Join(sealDir, "key.age.backup")
+		if err := os.WriteFile(backupPath, backup, 0600); err != nil {
+			return fmt.Errorf("writing key backup: %w", err)
+		}
+		fmt.Println("  Key backup saved.")
+	} else {
+		fmt.Println("  Skipping backup (no passphrase entered).")
 	}
 
 	// 5. Write default config
@@ -192,30 +208,6 @@ enclaude pull          # pull and decrypt latest
 enclaude status        # show unsealed changes not yet sealed
 {FENCE}
 `
-
-func createKeyBackup(sealDir, secretKey string) error {
-	fmt.Println()
-	passphrase, err := ui.ReadPassphraseOptional("Enter backup passphrase (for key recovery, blank to skip): ")
-	if err != nil {
-		return fmt.Errorf("reading backup passphrase: %w", err)
-	}
-
-	if passphrase != "" {
-		backup, err := crypto.EncryptWithPassphrase([]byte(secretKey), passphrase)
-		if err != nil {
-			return fmt.Errorf("creating key backup: %w", err)
-		}
-		backupPath := filepath.Join(sealDir, "key.age.backup")
-		if err := os.WriteFile(backupPath, backup, 0600); err != nil {
-			return fmt.Errorf("writing key backup: %w", err)
-		}
-		fmt.Println("  Key backup saved.")
-	} else {
-		fmt.Println("  Skipping backup (no passphrase entered).")
-	}
-
-	return nil
-}
 
 func buildReadme(publicKey, deviceID string) string {
 	return strings.NewReplacer(

--- a/cmd/remote.go
+++ b/cmd/remote.go
@@ -26,8 +26,8 @@ var remoteAddCmd = &cobra.Command{
 		}
 
 		// Register merge driver
-		driverCmd := "enclaude merge-driver manifest %O %A %B"
-		if err := git.ConfigMergeDriver("enclaude-manifest", driverCmd); err != nil {
+		driverArgs := []string{"merge-driver", "manifest", "%O", "%A", "%B"}
+		if err := git.ConfigMergeDriver("enclaude-manifest", driverArgs); err != nil {
 			fmt.Printf("Warning: could not register merge driver: %v\n", err)
 		}
 

--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -2,6 +2,7 @@ package gitops
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -123,11 +124,29 @@ func (g *Git) LogFull(n int) (string, error) {
 }
 
 // ConfigMergeDriver registers a custom merge driver.
-func (g *Git) ConfigMergeDriver(name, driverCmd string) error {
+func (g *Git) ConfigMergeDriver(name string, driverArgs []string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("getting executable path: %w", err)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("'" + strings.ReplaceAll(exe, "'", "'\\''") + "'")
+	for _, arg := range driverArgs {
+		sb.WriteString(" ")
+		// Git special tokens should not be quoted so they are expanded by git
+		if arg == "%O" || arg == "%A" || arg == "%B" || arg == "%L" || arg == "%P" {
+			sb.WriteString(arg)
+		} else {
+			sb.WriteString("'" + strings.ReplaceAll(arg, "'", "'\\''") + "'")
+		}
+	}
+	driverCmd := sb.String()
+
 	if _, err := g.run("config", fmt.Sprintf("merge.%s.name", name), "Claude Seal "+name+" merge"); err != nil {
 		return err
 	}
-	_, err := g.run("config", fmt.Sprintf("merge.%s.driver", name), driverCmd)
+	_, err = g.run("config", fmt.Sprintf("merge.%s.driver", name), driverCmd)
 	return err
 }
 

--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -130,6 +130,8 @@ func (g *Git) ConfigMergeDriver(name string, driverArgs []string) error {
 		return fmt.Errorf("getting executable path: %w", err)
 	}
 
+	// Note: os.Executable() on Linux can return a path under /proc/self/exe if unlinked
+	// Note: POSIX single-quote escape won't work natively on Windows cmd.exe without bash
 	var sb strings.Builder
 	sb.WriteString("'" + strings.ReplaceAll(exe, "'", "'\\''") + "'")
 	for _, arg := range driverArgs {

--- a/internal/gitops/git_test.go
+++ b/internal/gitops/git_test.go
@@ -1,0 +1,52 @@
+package gitops
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestConfigMergeDriverQuoting(t *testing.T) {
+	tmp := t.TempDir()
+	g := New(tmp)
+	if err := g.Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	// This is a test for the quoting logic inside ConfigMergeDriver.
+	// Since os.Executable() is used, the driver string will start with the test executable path.
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable failed: %v", err)
+	}
+
+	testArgs := []string{"merge-driver", "manifest", "has'quote", "%O", "%A", "%B"}
+	if err := g.ConfigMergeDriver("testdriver", testArgs); err != nil {
+		t.Fatalf("ConfigMergeDriver failed: %v", err)
+	}
+
+	// Check what was set in git config
+	out, err := g.run("config", "merge.testdriver.driver")
+	if err != nil {
+		t.Fatalf("failed to read git config: %v", err)
+	}
+	out = strings.TrimSpace(out)
+
+	// Validate quoting
+	expectedExe := "'" + strings.ReplaceAll(exe, "'", "'\\''") + "'"
+	if !strings.HasPrefix(out, expectedExe) {
+		t.Errorf("expected driver to start with %s, got %s", expectedExe, out)
+	}
+
+	if !strings.Contains(out, "'merge-driver'") {
+		t.Errorf("expected 'merge-driver' to be properly quoted, got %s", out)
+	}
+
+	if !strings.Contains(out, "'has'\\''quote'") {
+		t.Errorf("expected 'has'\\''quote' to be properly quoted, got %s", out)
+	}
+
+	if !strings.Contains(out, " %O %A %B") {
+		t.Errorf("expected git special tokens to remain unquoted, got %s", out)
+	}
+}


### PR DESCRIPTION
🎯 **What:** `ConfigMergeDriver` in `internal/gitops/git.go` previously stored the merge-driver git-config value as a hard-coded command string. This change has it accept a `driverArgs []string`, resolve the running binary via `os.Executable()`, and shell-quote each argument (preserving git's `%O`/`%A`/`%B`/`%L`/`%P` placeholders unquoted).

ℹ️ **Note — not a security fix:** An earlier revision of this PR framed this as fixing arbitrary code execution. That was inaccurate: the driver command was built from a constant string literal with no user-controlled input, so there was no injection surface. This is a robustness/hygiene hardening pass, not a CVE fix.

🛡️ **Why it's still worth doing:**
- Resolving the binary via `os.Executable()` makes the configured driver point at the exact binary that ran `enclaude remote add`, instead of relying on `enclaude` being on `PATH` at merge time (which breaks if the binary is moved or multiple versions are installed).
- Passing arguments as a list + explicit per-arg quoting removes any *future* injection surface if the driver command ever becomes dynamically constructed.
- `internal/gitops/git_test.go` adds `TestConfigMergeDriverQuoting` covering exe-path quoting, single-quote escaping, and git-token passthrough.

Caveats are documented inline: `os.Executable()` behavior on Linux for unlinked binaries, and that the POSIX single-quote escaping is not Windows-`cmd.exe`-native (current CI matrix is linux/darwin only).

---
*PR created automatically by Jules for task [3430774502075255699](https://jules.google.com/task/3430774502075255699) started by @coredipper*