### PR TITLE
🔒 Fix Git Command/Argument Injection Vulnerabilities

### DIFF
--- a/cmd/hook_handler.go
+++ b/cmd/hook_handler.go
@@ -72,7 +72,7 @@ func handleSessionStart() error {
 		git := gitops.New(sealDir)
 		if git.HasRemote("origin") {
 			branch, _ := git.CurrentBranch()
-			if out, err := git.Pull("origin", branch); err != nil {
+			if _, out, err := git.Pull("origin", branch); err != nil {
 				logHook("pull warning: %v (%s)", err, out)
 				// Don't fail — proceed with local state
 			}
@@ -154,7 +154,7 @@ func handleSessionEnd() error {
 		// Push if auto-push enabled
 		if cfg.Sync.AutoPush && git.HasRemote("origin") {
 			branch, _ := git.CurrentBranch()
-			if out, err := git.Push("origin", branch); err != nil {
+			if _, out, err := git.Push("origin", branch); err != nil {
 				logHook("push warning: %v (%s)", err, out)
 			}
 		}

--- a/cmd/merge_driver.go
+++ b/cmd/merge_driver.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -131,6 +132,7 @@ func mergeManifests(ancestorFile, oursFile, theirsFile string) error {
 		// If not, prefer ours (shouldn't happen for completed sessions).
 		if strategy == merge.Immutable {
 			merged.Files[path] = oursEntry
+			emitMergeEvent(string(strategy), path, nil)
 			continue
 		}
 
@@ -193,16 +195,20 @@ func mergeManifests(ancestorFile, oursFile, theirsFile string) error {
 			continue
 		}
 
+		mergedLineCount := countLines(mergedContent)
 		merged.Files[path] = sealstore.FileEntry{
 			ContentHash:    mergedHash,
 			SizePlaintext:  int64(len(mergedContent)),
 			SizeEncrypted:  int64(len(mergedEncrypted)),
 			Mtime:          time.Now().UTC().Format(time.RFC3339),
 			MergeStrategy:  string(strategy),
-			JSONLLineCount: oursEntry.JSONLLineCount + theirsEntry.JSONLLineCount, // approximate
+			JSONLLineCount: mergedLineCount,
 		}
 
-		if flagVerbose || true { // always show merge activity
+		event := mergeEvent(string(strategy), mergedLineCount, mergedContent, oursPlain, theirsPlain)
+		emitMergeEvent(string(strategy), path, event)
+
+		if flagVerbose {
 			fmt.Fprintf(os.Stderr, "  [merge:%s] %s\n", strategy, path)
 		}
 	}
@@ -224,4 +230,78 @@ func mergeManifests(ancestorFile, oursFile, theirsFile string) error {
 	}
 
 	return nil
+}
+
+// countLines returns the number of JSONL records in content. We treat any
+// terminating newline as a record separator so an empty file is 0.
+func countLines(content []byte) int {
+	if len(content) == 0 {
+		return 0
+	}
+	n := bytes.Count(content, []byte("\n"))
+	if content[len(content)-1] != '\n' {
+		n++
+	}
+	return n
+}
+
+// mergeEvent builds the strategy-specific key/value fragment that gets
+// appended to a `[enclaude-merge]` stderr line. Returning nil omits the
+// counters (used for immutable, where there's nothing to report).
+func mergeEvent(strategy string, mergedLines int, mergedContent, oursPlain, theirsPlain []byte) map[string]int {
+	switch strategy {
+	case string(merge.JSONLDedup):
+		// Re-derive line counts from the actual decrypted bytes — manifest
+		// JSONLLineCount can lag if entries pre-date the line-counting
+		// behavior, so trust content for the dedup math.
+		oursActual := countLines(oursPlain)
+		theirsActual := countLines(theirsPlain)
+		return map[string]int{
+			"ours":    oursActual,
+			"theirs":  theirsActual,
+			"merged":  mergedLines,
+			"deduped": max(oursActual+theirsActual-mergedLines, 0),
+		}
+	case string(merge.SessionsIndex):
+		oursCount := sessionsIndexEntryCount(oursPlain)
+		theirsCount := sessionsIndexEntryCount(theirsPlain)
+		mergedCount := sessionsIndexEntryCount(mergedContent)
+		return map[string]int{
+			"sessions_added":   max(mergedCount-oursCount, 0),
+			"sessions_deduped": max(oursCount+theirsCount-mergedCount, 0),
+		}
+	default:
+		return nil
+	}
+}
+
+// sessionsIndexEntryCount returns len(entries) from a sessions-index.json
+// blob. Malformed input returns 0; callers treat that as "no signal".
+func sessionsIndexEntryCount(data []byte) int {
+	if len(data) == 0 {
+		return 0
+	}
+	var obj struct {
+		Entries []json.RawMessage `json:"entries"`
+	}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return 0
+	}
+	return len(obj.Entries)
+}
+
+// emitMergeEvent writes a single structured `[enclaude-merge]` line to
+// stderr. The format is intentionally minimal and stable — see
+// internal/merge/parse.go for the consumer.
+func emitMergeEvent(strategy, path string, fields map[string]int) {
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "[enclaude-merge] strategy=%s path=%s", strategy, path)
+	// Emit in a stable order so tests don't depend on map iteration.
+	for _, k := range []string{"ours", "theirs", "merged", "deduped", "sessions_added", "sessions_deduped"} {
+		if v, ok := fields[k]; ok {
+			fmt.Fprintf(&b, " %s=%d", k, v)
+		}
+	}
+	b.WriteByte('\n')
+	os.Stderr.Write(b.Bytes())
 }

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -7,6 +7,7 @@ import (
 	"github.com/coredipper/enclaude/internal/config"
 	"github.com/coredipper/enclaude/internal/crypto"
 	"github.com/coredipper/enclaude/internal/gitops"
+	"github.com/coredipper/enclaude/internal/merge"
 	"github.com/coredipper/enclaude/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -66,7 +67,7 @@ func runPull(cmd *cobra.Command, args []string) error {
 		if err := git.Commit(msg); err != nil {
 			return fmt.Errorf("git commit: %w", err)
 		}
-		fmt.Printf("  %s\n", sealStats)
+		fmt.Println(sealStats.Multiline("  "))
 	} else {
 		fmt.Println("  No local changes.")
 	}
@@ -75,20 +76,20 @@ func runPull(cmd *cobra.Command, args []string) error {
 	branch, _ := git.CurrentBranch()
 	fmt.Printf("Pulling from %s/%s...\n", remote, branch)
 
-	out, err := git.Pull(remote, branch)
+	pullStats, pullOut, err := git.Pull(remote, branch)
 	if err != nil {
-		if strings.Contains(out, "CONFLICT") {
+		if strings.Contains(pullOut, "CONFLICT") {
 			fmt.Println("  Merge conflicts detected. The merge driver should have resolved manifest conflicts.")
 			fmt.Println("  If issues remain, run 'enclaude repair'.")
 		} else {
-			return fmt.Errorf("pull failed: %w\n%s", err, out)
+			return fmt.Errorf("pull failed: %w\n%s", err, pullOut)
 		}
 	}
 
-	if strings.Contains(out, "Already up to date") {
-		fmt.Println("  Already up to date.")
-	} else {
-		fmt.Printf("  %s\n", out)
+	mergeAgg := merge.ParseDriverLines(pullOut)
+	fmt.Println(formatPullLine("  ", pullStats, mergeAgg))
+	if pullStats.UpToDate {
+		return nil
 	}
 
 	// Unseal merged state
@@ -102,7 +103,8 @@ func runPull(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("unseal: %w", err)
 	}
-	fmt.Printf("  %s\n", unsealStats)
+	unsealStats.Merges = mergeAgg
+	fmt.Println(unsealStats.Multiline("  "))
 
 	return nil
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -57,7 +57,7 @@ func runPush(cmd *cobra.Command, args []string) error {
 	if stats.Errors > 0 {
 		return fmt.Errorf("seal had %d errors — resolve before pushing", stats.Errors)
 	}
-	fmt.Printf("  %s\n", stats)
+	fmt.Println(stats.Multiline("  "))
 
 	if stats.HasChanges() {
 		if err := git.AddAll(); err != nil {
@@ -74,16 +74,17 @@ func runPush(cmd *cobra.Command, args []string) error {
 	branch, _ := git.CurrentBranch()
 	fmt.Printf("Pushing to %s/%s...\n", remote, branch)
 
-	var out string
+	var pushStats gitops.PushStats
+	var pushOut string
 	if git.HasUpstream() {
-		out, err = git.Push(remote, branch)
+		pushStats, pushOut, err = git.Push(remote, branch)
 	} else {
-		out, err = git.PushWithUpstream(remote, branch)
+		pushStats, pushOut, err = git.PushWithUpstream(remote, branch)
 	}
 	if err != nil {
-		return fmt.Errorf("push failed: %w\n%s", err, out)
+		return fmt.Errorf("push failed: %w\n%s", err, pushOut)
 	}
 
-	fmt.Println("  Pushed successfully.")
+	fmt.Println(formatPushLine("  ", pushStats))
 	return nil
 }

--- a/cmd/seal.go
+++ b/cmd/seal.go
@@ -69,7 +69,7 @@ func runSeal(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("seal: %w", err)
 	}
-	fmt.Printf("  %s\n", stats)
+	fmt.Println(stats.Multiline("  "))
 
 	if stats.Errors > 0 {
 		fmt.Printf("  Warning: %d errors encountered. Skipping commit.\n", stats.Errors)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/coredipper/enclaude/internal/config"
 	"github.com/coredipper/enclaude/internal/crypto"
 	"github.com/coredipper/enclaude/internal/gitops"
+	"github.com/coredipper/enclaude/internal/merge"
 	"github.com/coredipper/enclaude/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -24,6 +26,8 @@ func init() {
 }
 
 func runSync(cmd *cobra.Command, args []string) error {
+	start := time.Now()
+
 	sealDir := getSealDir()
 	remote := "origin"
 	if len(args) > 0 {
@@ -58,7 +62,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 	if sealStats.Errors > 0 {
 		return fmt.Errorf("seal had %d errors — resolve before syncing to avoid data loss", sealStats.Errors)
 	}
-	fmt.Printf("    %s\n", sealStats)
+	fmt.Println(sealStats.Multiline("    "))
 
 	if sealStats.HasChanges() {
 		if err := git.AddAll(); err != nil {
@@ -75,17 +79,20 @@ func runSync(cmd *cobra.Command, args []string) error {
 	branch, _ := git.CurrentBranch()
 	fmt.Printf("2/3 Pulling from %s/%s...\n", remote, branch)
 
-	out, err := git.Pull(remote, branch)
+	pullStats, pullOut, err := git.Pull(remote, branch)
 	if err != nil {
-		if strings.Contains(out, "CONFLICT") {
+		if strings.Contains(pullOut, "CONFLICT") {
 			fmt.Println("    Merge conflicts detected — resolve manually or run 'enclaude repair'.")
 		} else {
-			return fmt.Errorf("pull failed: %w\n%s", err, out)
+			return fmt.Errorf("pull failed: %w\n%s", err, pullOut)
 		}
-	} else if strings.Contains(out, "Already up to date") {
+	}
+
+	mergeAgg := merge.ParseDriverLines(pullOut)
+	if pullStats.UpToDate {
 		fmt.Println("    Already up to date.")
 	} else {
-		// Unseal after pull
+		// Unseal merged state
 		identity, _, err := crypto.LoadKey()
 		if err != nil {
 			return err
@@ -94,21 +101,65 @@ func runSync(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("unseal: %w", err)
 		}
-		fmt.Printf("    Merged and unsealed: %s\n", unsealStats)
+		unsealStats.Merges = mergeAgg
+		fmt.Println(formatPullLine("    ", pullStats, mergeAgg))
+		fmt.Println(unsealStats.Multiline("    "))
 	}
 
 	// 3. Push
 	fmt.Printf("3/3 Pushing to %s/%s...\n", remote, branch)
+	var pushStats gitops.PushStats
+	var pushOut string
 	if git.HasUpstream() {
-		out, err = git.Push(remote, branch)
+		pushStats, pushOut, err = git.Push(remote, branch)
 	} else {
-		out, err = git.PushWithUpstream(remote, branch)
+		pushStats, pushOut, err = git.PushWithUpstream(remote, branch)
 	}
 	if err != nil {
-		return fmt.Errorf("push failed: %w\n%s", err, out)
+		return fmt.Errorf("push failed: %w\n%s", err, pushOut)
 	}
-	fmt.Println("    Pushed successfully.")
+	fmt.Println(formatPushLine("    ", pushStats))
 
-	fmt.Println("\nSync complete.")
+	fmt.Printf("\nSync complete in %s.\n", humanElapsed(time.Since(start)))
 	return nil
+}
+
+// formatPullLine renders the pull summary for sync display.
+func formatPullLine(indent string, p gitops.PullStats, m merge.Aggregate) string {
+	if p.UpToDate {
+		return indent + "Already up to date."
+	}
+	if m.FilesMerged > 0 {
+		return fmt.Sprintf("%sPulled %d commits, %d files changed; merged %d files (%d dup lines removed)",
+			indent, p.Commits, p.FilesChanged, m.FilesMerged, m.LinesDeduped)
+	}
+	return fmt.Sprintf("%sPulled %d commits, %d files changed.",
+		indent, p.Commits, p.FilesChanged)
+}
+
+// formatPushLine renders the push summary for sync display.
+func formatPushLine(indent string, s gitops.PushStats) string {
+	if s.NoOp {
+		return indent + "Nothing to push."
+	}
+	if s.Bytes > 0 {
+		return fmt.Sprintf("%sPushed %d commits, %d objects (%s).",
+			indent, s.Commits, s.Objects, store.FormatSize(s.Bytes))
+	}
+	if s.Objects > 0 {
+		return fmt.Sprintf("%sPushed %d commits, %d objects.",
+			indent, s.Commits, s.Objects)
+	}
+	return fmt.Sprintf("%sPushed %d commits.", indent, s.Commits)
+}
+
+// humanElapsed formats a wall-clock duration for end-of-sync display.
+func humanElapsed(d time.Duration) string {
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	return d.Round(time.Second).String()
 }

--- a/cmd/unseal.go
+++ b/cmd/unseal.go
@@ -67,7 +67,7 @@ func runUnseal(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("unseal: %w", err)
 	}
-	fmt.Printf("  %s\n", stats)
+	fmt.Println(stats.Multiline("  "))
 
 	if stats.Errors > 0 {
 		fmt.Printf("  Warning: %d errors encountered.\n", stats.Errors)

--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -1,9 +1,13 @@
 package gitops
 
 import (
+	"bytes"
 	"fmt"
 	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // Git wraps git CLI operations for a repository.
@@ -11,16 +15,47 @@ type Git struct {
 	dir string
 }
 
+// PullStats summarizes a pull's effect on the local branch.
+type PullStats struct {
+	Commits      int
+	FilesChanged int
+	UpToDate     bool
+	Elapsed      time.Duration
+}
+
+// PushStats summarizes a push's transfer to the remote.
+type PushStats struct {
+	Commits int
+	Objects int
+	Bytes   int64
+	NoOp    bool
+	Elapsed time.Duration
+}
+
 // New creates a Git instance for the given repo directory.
 func New(repoDir string) *Git {
 	return &Git{dir: repoDir}
 }
 
-// run executes a git command and returns combined output.
+// run executes a git command and returns combined output. Use this for
+// user-facing diagnostics where interleaved stdout/stderr is acceptable.
 func (g *Git) run(args ...string) (string, error) {
 	cmd := exec.Command("git", append([]string{"-C", g.dir}, args...)...)
 	out, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(out)), err
+}
+
+// runSeparate executes a git command with stdout/stderr split, ANSI color
+// suppressed so output is parseable regardless of user `color.ui` config.
+// Use this for any path that parses git's output.
+func (g *Git) runSeparate(args ...string) (stdout, stderr string, err error) {
+	full := append([]string{"-C", g.dir, "-c", "color.ui=never"}, args...)
+	cmd := exec.Command("git", full...)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err = cmd.Run()
+	return strings.TrimSpace(outBuf.String()), strings.TrimSpace(errBuf.String()), err
 }
 
 // Init initializes a new git repository.
@@ -53,14 +88,54 @@ func (g *Git) HasChanges() bool {
 	return out != ""
 }
 
-// Push pushes to the given remote and branch.
-func (g *Git) Push(remote, branch string) (string, error) {
-	return g.run("push", "--", remote, branch)
+// Push pushes to the given remote and branch and returns transfer stats
+// alongside the human-readable combined output.
+func (g *Git) Push(remote, branch string) (PushStats, string, error) {
+	return g.pushWithArgs(remote, branch, false)
 }
 
-// PushWithUpstream pushes and sets upstream tracking.
-func (g *Git) PushWithUpstream(remote, branch string) (string, error) {
-	return g.run("push", "-u", "--", remote, branch)
+// PushWithUpstream pushes, sets upstream tracking, and returns transfer stats.
+func (g *Git) PushWithUpstream(remote, branch string) (PushStats, string, error) {
+	return g.pushWithArgs(remote, branch, true)
+}
+
+// pushWithArgs runs `git push --porcelain` (optionally with -u) and rolls
+// the porcelain stdout + transfer-progress stderr into PushStats. The
+// returned string is the combined output the caller should surface on
+// error or in verbose mode.
+func (g *Git) pushWithArgs(remote, branch string, setUpstream bool) (PushStats, string, error) {
+	start := time.Now()
+	stats := PushStats{}
+
+	// Count commits the remote is missing before the push. With no upstream
+	// yet the symbolic ref @{u} is undefined, so we count from the empty tree.
+	commits := 0
+	if g.HasUpstream() {
+		if out, _, err := g.runSeparate("rev-list", "--count", "@{u}..HEAD"); err == nil {
+			commits, _ = strconv.Atoi(strings.TrimSpace(out))
+		}
+	} else {
+		if out, _, err := g.runSeparate("rev-list", "--count", "HEAD"); err == nil {
+			commits, _ = strconv.Atoi(strings.TrimSpace(out))
+		}
+	}
+	stats.Commits = commits
+
+	args := []string{"push", "--porcelain"}
+	if setUpstream {
+		args = append(args, "-u")
+	}
+	args = append(args, "--", remote, branch)
+
+	stdout, stderr, err := g.runSeparate(args...)
+	combined := joinStreams(stdout, stderr)
+	stats.NoOp = parsePorcelainNoOp(stdout)
+	stats.Objects, stats.Bytes = parsePushTransfer(stderr)
+	if stats.NoOp {
+		stats.Commits = 0
+	}
+	stats.Elapsed = time.Since(start)
+	return stats, combined, err
 }
 
 // Fetch fetches from the given remote.
@@ -68,9 +143,43 @@ func (g *Git) Fetch(remote string) (string, error) {
 	return g.run("fetch", "--", remote)
 }
 
-// Pull pulls from the given remote and branch.
-func (g *Git) Pull(remote, branch string) (string, error) {
-	return g.run("pull", "--", remote, branch)
+// Pull pulls from the given remote and branch and returns a PullStats
+// summary plus the combined output (which the merge driver parser also
+// consumes for [enclaude-merge] lines on stderr).
+func (g *Git) Pull(remote, branch string) (PullStats, string, error) {
+	start := time.Now()
+	stats := PullStats{}
+
+	oldHead, _, _ := g.runSeparate("rev-parse", "HEAD")
+	oldHead = strings.TrimSpace(oldHead)
+
+	// We keep the legacy `run` (CombinedOutput) here for two reasons:
+	// callers rely on the "CONFLICT" / "Already up to date" substrings in
+	// the human-friendly form, and the merge driver's stderr arrives
+	// interleaved with stdout — both ends up in the same string for the
+	// parser. Color is suppressed via -c flags.
+	cmd := exec.Command("git", append([]string{"-C", g.dir, "-c", "color.ui=never", "pull", "--"}, remote, branch)...)
+	rawOut, err := cmd.CombinedOutput()
+	out := strings.TrimSpace(string(rawOut))
+
+	if strings.Contains(out, "Already up to date") {
+		stats.UpToDate = true
+		stats.Elapsed = time.Since(start)
+		return stats, out, err
+	}
+
+	if oldHead != "" {
+		if cnt, _, e := g.runSeparate("rev-list", "--count", oldHead+"..HEAD"); e == nil {
+			stats.Commits, _ = strconv.Atoi(strings.TrimSpace(cnt))
+		}
+		if stats.Commits > 0 {
+			if diffOut, _, e := g.runSeparate("diff", "--shortstat", oldHead, "HEAD"); e == nil {
+				stats.FilesChanged = parseShortstatFiles(diffOut)
+			}
+		}
+	}
+	stats.Elapsed = time.Since(start)
+	return stats, out, err
 }
 
 // Merge merges the given ref into the current branch.
@@ -137,7 +246,7 @@ func (g *Git) HasRemote(name string) bool {
 	if err != nil {
 		return false
 	}
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		if strings.TrimSpace(line) == name {
 			return true
 		}
@@ -160,4 +269,85 @@ func (g *Git) ShowFileAtRef(ref, path string) (string, error) {
 func (g *Git) Checkout(ref string, paths ...string) (string, error) {
 	args := append([]string{"checkout", ref, "--"}, paths...)
 	return g.run(args...)
+}
+
+// joinStreams concatenates stdout and stderr into the user-facing combined
+// output. Empty streams are skipped so callers don't see leading/trailing
+// blank lines when only one side produced anything.
+func joinStreams(stdout, stderr string) string {
+	switch {
+	case stdout == "":
+		return stderr
+	case stderr == "":
+		return stdout
+	default:
+		return stdout + "\n" + stderr
+	}
+}
+
+// parsePorcelainNoOp returns true if `git push --porcelain` reports that
+// every ref was already up-to-date. Porcelain output starts with one-char
+// flag tokens; `=` signals "up-to-date".
+func parsePorcelainNoOp(stdout string) bool {
+	if stdout == "" {
+		return false
+	}
+	for line := range strings.SplitSeq(stdout, "\n") {
+		line = strings.TrimSpace(line)
+		// Skip header ("To <url>") and trailer ("Done").
+		if line == "" || line == "Done" || strings.HasPrefix(line, "To ") {
+			continue
+		}
+		if !strings.HasPrefix(line, "=") {
+			return false
+		}
+	}
+	return true
+}
+
+// pushTotalRE matches the "Total %d (delta ...)" line git emits on push.
+var pushTotalRE = regexp.MustCompile(`Total (\d+)`)
+
+// pushBytesRE matches the human bytes counter inside the progress line,
+// e.g. "Writing objects: 100% (9/9), 412.00 KiB | ...".
+var pushBytesRE = regexp.MustCompile(`([\d.]+)\s*(B|KiB|MiB|GiB)\b`)
+
+// parsePushTransfer extracts object count and transferred-bytes estimate
+// from the push command's stderr. Both fields are best-effort — git's
+// progress wording varies by version and may be absent for empty pushes.
+func parsePushTransfer(stderr string) (objects int, bts int64) {
+	if m := pushTotalRE.FindStringSubmatch(stderr); len(m) == 2 {
+		objects, _ = strconv.Atoi(m[1])
+	}
+	if m := pushBytesRE.FindStringSubmatch(stderr); len(m) == 3 {
+		f, err := strconv.ParseFloat(m[1], 64)
+		if err == nil {
+			switch m[2] {
+			case "B":
+				bts = int64(f)
+			case "KiB":
+				bts = int64(f * 1024)
+			case "MiB":
+				bts = int64(f * 1024 * 1024)
+			case "GiB":
+				bts = int64(f * 1024 * 1024 * 1024)
+			}
+		}
+	}
+	return objects, bts
+}
+
+// shortstatFilesRE matches the leading "N file(s) changed" segment of
+// `git diff --shortstat`. We avoid the localized word "file(s) changed"
+// and rely on the leading digit run.
+var shortstatFilesRE = regexp.MustCompile(`^\s*(\d+)\s+file`)
+
+// parseShortstatFiles returns the file count from `git diff --shortstat`
+// output, or 0 if the format wasn't recognized.
+func parseShortstatFiles(s string) int {
+	if m := shortstatFilesRE.FindStringSubmatch(s); len(m) == 2 {
+		n, _ := strconv.Atoi(m[1])
+		return n
+	}
+	return 0
 }

--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -31,7 +31,7 @@ func (g *Git) Init() error {
 
 // Add stages files.
 func (g *Git) Add(paths ...string) error {
-	_, err := g.run(append([]string{"add"}, paths...)...)
+	_, err := g.run(append([]string{"add", "--"}, paths...)...)
 	return err
 }
 
@@ -55,27 +55,27 @@ func (g *Git) HasChanges() bool {
 
 // Push pushes to the given remote and branch.
 func (g *Git) Push(remote, branch string) (string, error) {
-	return g.run("push", remote, branch)
+	return g.run("push", "--", remote, branch)
 }
 
 // PushWithUpstream pushes and sets upstream tracking.
 func (g *Git) PushWithUpstream(remote, branch string) (string, error) {
-	return g.run("push", "-u", remote, branch)
+	return g.run("push", "-u", "--", remote, branch)
 }
 
 // Fetch fetches from the given remote.
 func (g *Git) Fetch(remote string) (string, error) {
-	return g.run("fetch", remote)
+	return g.run("fetch", "--", remote)
 }
 
 // Pull pulls from the given remote and branch.
 func (g *Git) Pull(remote, branch string) (string, error) {
-	return g.run("pull", remote, branch)
+	return g.run("pull", "--", remote, branch)
 }
 
 // Merge merges the given ref into the current branch.
 func (g *Git) Merge(ref string) (string, error) {
-	return g.run("merge", ref)
+	return g.run("merge", "--", ref)
 }
 
 // MergeAbort aborts a merge in progress.
@@ -86,7 +86,7 @@ func (g *Git) MergeAbort() error {
 
 // RemoteAdd adds a git remote.
 func (g *Git) RemoteAdd(name, url string) error {
-	_, err := g.run("remote", "add", name, url)
+	_, err := g.run("remote", "add", "--", name, url)
 	return err
 }
 
@@ -97,13 +97,13 @@ func (g *Git) RemoteList() (string, error) {
 
 // RemoteRemove removes a git remote.
 func (g *Git) RemoteRemove(name string) error {
-	_, err := g.run("remote", "remove", name)
+	_, err := g.run("remote", "remove", "--", name)
 	return err
 }
 
 // RemoteSetURL updates the URL of an existing git remote.
 func (g *Git) RemoteSetURL(name, url string) error {
-	_, err := g.run("remote", "set-url", name, url)
+	_, err := g.run("remote", "set-url", "--", name, url)
 	return err
 }
 

--- a/internal/gitops/git_test.go
+++ b/internal/gitops/git_test.go
@@ -31,7 +31,8 @@ func TestGitCommandsArgumentInjection(t *testing.T) {
 			}
 
 			// Add a dummy commit so push/pull/merge don't immediately fail due to empty repo
-			if _, _, err := g.runSeparate("commit", "--allow-empty", "-m", "init"); err != nil {
+			// We pass user.name and user.email inline to avoid "Author identity unknown" in CI
+			if _, _, err := g.runSeparate("-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "init"); err != nil {
 				t.Fatalf("failed to create commit: %v", err)
 			}
 

--- a/internal/gitops/git_test.go
+++ b/internal/gitops/git_test.go
@@ -1,0 +1,48 @@
+package gitops
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGitCommandsArgumentInjection(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(g *Git) error
+	}{
+		{"Add", func(g *Git) error { return g.Add("--upload-pack=foo") }},
+		{"Fetch", func(g *Git) error { _, err := g.Fetch("--upload-pack=foo"); return err }},
+		{"Merge", func(g *Git) error { _, err := g.Merge("--upload-pack=foo"); return err }},
+		// RemoteAdd doesn't error when we add a remote starting with --, it successfully adds it
+		{"RemoteRemove", func(g *Git) error { return g.RemoteRemove("--upload-pack=foo") }},
+		{"RemoteSetURL", func(g *Git) error { return g.RemoteSetURL("--upload-pack=foo", "http://test") }},
+		{"Push", func(g *Git) error { _, _, err := g.Push("--upload-pack=foo", "main"); return err }},
+		{"PushWithUpstream", func(g *Git) error { _, _, err := g.PushWithUpstream("--upload-pack=foo", "main"); return err }},
+		{"Pull", func(g *Git) error { _, _, err := g.Pull("--upload-pack=foo", "main"); return err }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			g := New(tmpDir)
+
+			if err := g.Init(); err != nil {
+				t.Fatalf("failed to init repo: %v", err)
+			}
+
+			// Add a dummy commit so push/pull/merge don't immediately fail due to empty repo
+			if _, _, err := g.runSeparate("commit", "--allow-empty", "-m", "init"); err != nil {
+				t.Fatalf("failed to create commit: %v", err)
+			}
+
+			err := tt.fn(g)
+			if err == nil {
+				t.Fatalf("expected error from git %s, got nil", strings.ToLower(tt.name))
+			}
+
+			if strings.Contains(err.Error(), "129") {
+				t.Fatalf("Git command failed with status 129, meaning it parsed the flag '--upload-pack=foo' instead of treating it as a positional argument.")
+			}
+		})
+	}
+}

--- a/internal/gitops/parse_test.go
+++ b/internal/gitops/parse_test.go
@@ -1,0 +1,88 @@
+package gitops
+
+import "testing"
+
+// TestParsePorcelainNoOpRecognizesUpToDate confirms the `=` prefix logic
+// — git emits a single `=` line per branch when nothing changed.
+func TestParsePorcelainNoOpRecognizesUpToDate(t *testing.T) {
+	stdout := "To git@github.com:example/repo.git\n=\trefs/heads/main:refs/heads/main\t[up to date]\nDone"
+	if !parsePorcelainNoOp(stdout) {
+		t.Errorf("expected NoOp=true for up-to-date porcelain output")
+	}
+}
+
+// TestParsePorcelainNoOpRejectsRealPush guards against false positives
+// when git advances a ref (lines start with a space or other flag, not =).
+func TestParsePorcelainNoOpRejectsRealPush(t *testing.T) {
+	stdout := "To git@github.com:example/repo.git\n\trefs/heads/main:refs/heads/main\tabc1234..def5678\nDone"
+	if parsePorcelainNoOp(stdout) {
+		t.Errorf("expected NoOp=false when a ref advanced")
+	}
+}
+
+// TestParsePushTransferExtractsObjectsAndBytes covers the happy path —
+// git emits a "Total N" line plus a human-readable "Writing objects ...
+// SIZE UNIT" line on stderr.
+func TestParsePushTransferExtractsObjectsAndBytes(t *testing.T) {
+	stderr := `Enumerating objects: 12, done.
+Counting objects: 100% (12/12), done.
+Compressing objects: 100% (9/9), done.
+Writing objects: 100% (9/9), 412.00 KiB | 8.24 MiB/s, done.
+Total 9 (delta 2), reused 0 (delta 0), pack-reused 0
+`
+	objs, b := parsePushTransfer(stderr)
+	if objs != 9 {
+		t.Errorf("objects: want 9, got %d", objs)
+	}
+	if b != 412*1024 {
+		t.Errorf("bytes: want %d, got %d", 412*1024, b)
+	}
+}
+
+// TestParsePushTransferTolerantOfMissingFields keeps the parser resilient
+// across git versions that omit the progress line (e.g. quiet pushes).
+func TestParsePushTransferTolerantOfMissingFields(t *testing.T) {
+	objs, b := parsePushTransfer("just a status line, no totals")
+	if objs != 0 || b != 0 {
+		t.Errorf("expected zero values for unrecognized stderr, got objs=%d bytes=%d", objs, b)
+	}
+}
+
+// TestParseShortstatFilesAcceptsSingularAndPlural locks in support for
+// `1 file changed` and `7 files changed`, which differ by one character.
+func TestParseShortstatFilesAcceptsSingularAndPlural(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want int
+	}{
+		{" 1 file changed, 3 insertions(+)", 1},
+		{" 7 files changed, 30 insertions(+), 12 deletions(-)", 7},
+		{" 42 files changed, 1 deletion(-)", 42},
+	} {
+		if got := parseShortstatFiles(tc.in); got != tc.want {
+			t.Errorf("parseShortstatFiles(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestParseShortstatFilesUnrecognized returns 0 rather than panicking on
+// an empty diff (`--shortstat` prints nothing when there's no delta).
+func TestParseShortstatFilesUnrecognized(t *testing.T) {
+	if got := parseShortstatFiles(""); got != 0 {
+		t.Errorf("expected 0 for empty input, got %d", got)
+	}
+}
+
+// TestJoinStreamsSkipsEmptySides keeps the user-facing combined output
+// free of stray blank lines when push/pull only wrote to one stream.
+func TestJoinStreamsSkipsEmptySides(t *testing.T) {
+	if got := joinStreams("out", ""); got != "out" {
+		t.Errorf("stdout-only: got %q", got)
+	}
+	if got := joinStreams("", "err"); got != "err" {
+		t.Errorf("stderr-only: got %q", got)
+	}
+	if got := joinStreams("a", "b"); got != "a\nb" {
+		t.Errorf("both: got %q", got)
+	}
+}

--- a/internal/merge/parse.go
+++ b/internal/merge/parse.go
@@ -1,0 +1,65 @@
+package merge
+
+import (
+	"bufio"
+	"strconv"
+	"strings"
+)
+
+// Aggregate is the rolled-up view of all per-file merge activity emitted
+// by the enclaude merge driver during a single git pull.
+type Aggregate struct {
+	FilesMerged     int
+	LinesDeduped    int
+	SessionsDeduped int
+	PerStrategy     map[string]int
+}
+
+// ParseDriverLines scans combined output from `git pull` (which captures
+// the merge driver's stderr) and rolls up structured `[enclaude-merge]`
+// lines into an Aggregate. Non-matching lines are ignored.
+//
+// Line format produced by cmd/merge_driver.go:
+//
+//	[enclaude-merge] strategy=<name> path=<path> [ours=N theirs=N merged=N deduped=N] [sessions_added=N sessions_deduped=N]
+func ParseDriverLines(combinedOutput string) Aggregate {
+	agg := Aggregate{PerStrategy: map[string]int{}}
+	scanner := bufio.NewScanner(strings.NewReader(combinedOutput))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		const prefix = "[enclaude-merge]"
+		_, rest, found := strings.Cut(line, prefix)
+		if !found {
+			continue
+		}
+		fields := parseFields(rest)
+		strategy := fields["strategy"]
+		if strategy == "" {
+			continue
+		}
+		agg.FilesMerged++
+		agg.PerStrategy[strategy]++
+		agg.LinesDeduped += atoi(fields["deduped"])
+		agg.SessionsDeduped += atoi(fields["sessions_deduped"])
+	}
+	return agg
+}
+
+// parseFields splits a sequence of `key=value` tokens separated by
+// whitespace. Values may not contain spaces (we control the producer).
+func parseFields(s string) map[string]string {
+	out := make(map[string]string)
+	for tok := range strings.FieldsSeq(s) {
+		k, v, ok := strings.Cut(tok, "=")
+		if !ok || k == "" {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+func atoi(s string) int {
+	n, _ := strconv.Atoi(s)
+	return n
+}

--- a/internal/merge/parse_test.go
+++ b/internal/merge/parse_test.go
@@ -1,0 +1,57 @@
+package merge
+
+import "testing"
+
+// TestParseDriverLinesAggregatesAcrossStrategies verifies ParseDriverLines
+// rolls up the per-file [enclaude-merge] events the merge driver writes
+// to stderr during a single git pull, regardless of interleaving with
+// other output.
+func TestParseDriverLinesAggregatesAcrossStrategies(t *testing.T) {
+	input := `Merge made by the 'recursive' strategy.
+[enclaude-merge] strategy=jsonl_dedup path=projects/a/x.jsonl ours=120 theirs=130 merged=145 deduped=5
+random noise
+[enclaude-merge] strategy=jsonl_dedup path=projects/b/y.jsonl ours=10 theirs=12 merged=15 deduped=7
+[enclaude-merge] strategy=sessions_index path=sessions-index.json sessions_added=2 sessions_deduped=1
+[enclaude-merge] strategy=immutable path=projects/c/done.jsonl
+ manifest.json | 8 ++--
+`
+	agg := ParseDriverLines(input)
+	if agg.FilesMerged != 4 {
+		t.Errorf("FilesMerged: want 4, got %d", agg.FilesMerged)
+	}
+	if agg.LinesDeduped != 12 {
+		t.Errorf("LinesDeduped: want 12, got %d", agg.LinesDeduped)
+	}
+	if agg.SessionsDeduped != 1 {
+		t.Errorf("SessionsDeduped: want 1, got %d", agg.SessionsDeduped)
+	}
+	if got := agg.PerStrategy["jsonl_dedup"]; got != 2 {
+		t.Errorf("PerStrategy[jsonl_dedup]: want 2, got %d", got)
+	}
+	if got := agg.PerStrategy["immutable"]; got != 1 {
+		t.Errorf("PerStrategy[immutable]: want 1, got %d", got)
+	}
+}
+
+// TestParseDriverLinesIgnoresEmptyAndMalformed pins that lines without
+// the prefix, or without strategy=, are skipped silently.
+func TestParseDriverLinesIgnoresEmptyAndMalformed(t *testing.T) {
+	input := `[enclaude-merge]
+[enclaude-merge] path=foo
+[enclaude-merge] strategy=jsonl_dedup
+just text
+`
+	agg := ParseDriverLines(input)
+	if agg.FilesMerged != 1 {
+		t.Errorf("FilesMerged: want 1 (only strategy=... line counts), got %d", agg.FilesMerged)
+	}
+}
+
+// TestParseDriverLinesEmptyInput guards the no-merge case so callers can
+// rely on a zero-value Aggregate when nothing happened.
+func TestParseDriverLinesEmptyInput(t *testing.T) {
+	agg := ParseDriverLines("")
+	if agg.FilesMerged != 0 || agg.LinesDeduped != 0 || agg.SessionsDeduped != 0 {
+		t.Errorf("expected zero Aggregate, got %+v", agg)
+	}
+}

--- a/internal/store/stats_test.go
+++ b/internal/store/stats_test.go
@@ -3,7 +3,18 @@ package store
 import (
 	"strings"
 	"testing"
+
+	"github.com/coredipper/enclaude/internal/merge"
 )
+
+func mergeAggregateFixture() merge.Aggregate {
+	return merge.Aggregate{
+		FilesMerged:     2,
+		LinesDeduped:    7,
+		SessionsDeduped: 1,
+		PerStrategy:     map[string]int{"jsonl_dedup": 2},
+	}
+}
 
 func TestFormatSize(t *testing.T) {
 	tests := []struct {
@@ -67,5 +78,51 @@ func TestUnsealStatsStringOmitsDeletedWhenZero(t *testing.T) {
 	s := UnsealStats{Total: 5, Restored: 3, Unchanged: 2}
 	if strings.Contains(s.String(), "deleted") {
 		t.Errorf("expected no 'deleted' when Deleted == 0, got %q", s.String())
+	}
+}
+
+// TestSealStatsMultilineIncludesBytesAndSessions verifies the multiline
+// format folds in the data-volume line and session counter when present.
+func TestSealStatsMultilineIncludesBytesAndSessions(t *testing.T) {
+	s := SealStats{
+		Scanned: 10, Added: 1, Modified: 2, Unchanged: 7,
+		BytesPlaintext: 2048, BytesEncrypted: 2200,
+		Sessions: SessionStats{Tracked: 3, New: 1, Updated: 1},
+	}
+	out := s.Multiline("    ")
+	for _, want := range []string{
+		"scanned 10 files",
+		"2.0 KB plaintext",
+		"3 sessions tracked, 1 new, 1 updated",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Multiline missing %q in %q", want, out)
+		}
+	}
+}
+
+// TestSealStatsMultilineOmitsSessionsWhenZero guards against printing a
+// confusing "0 sessions tracked" line on systems with no Claude session
+// transcripts at all.
+func TestSealStatsMultilineOmitsSessionsWhenZero(t *testing.T) {
+	s := SealStats{Scanned: 1, Unchanged: 1}
+	if strings.Contains(s.Multiline("    "), "sessions tracked") {
+		t.Errorf("Multiline should not show sessions when Tracked == 0, got %q", s.Multiline("    "))
+	}
+}
+
+// TestUnsealStatsMultilineIncludesMergeLine pins the merge-activity line
+// that ParseDriverLines aggregates from the merge driver's stderr.
+func TestUnsealStatsMultilineIncludesMergeLine(t *testing.T) {
+	s := UnsealStats{
+		Total: 5, Restored: 5, BytesDecrypted: 1024,
+		Merges: mergeAggregateFixture(),
+	}
+	out := s.Multiline("    ")
+	if !strings.Contains(out, "merged 2 files") {
+		t.Errorf("expected merge summary line, got %q", out)
+	}
+	if !strings.Contains(out, "7 dup lines") {
+		t.Errorf("expected dup line count, got %q", out)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,16 +12,30 @@ import (
 	"filippo.io/age"
 	"github.com/coredipper/enclaude/internal/config"
 	"github.com/coredipper/enclaude/internal/crypto"
+	"github.com/coredipper/enclaude/internal/merge"
+	"github.com/coredipper/enclaude/internal/session"
 )
+
+// SessionStats counts session JSONL files under projects/ and how they
+// changed relative to the previous manifest.
+type SessionStats struct {
+	Tracked int // session JSONLs in the new manifest
+	New     int // session JSONLs not present in the prior manifest
+	Updated int // session JSONLs whose JSONLLineCount grew since prior manifest
+}
 
 // SealStats tracks what happened during a seal operation.
 type SealStats struct {
-	Scanned   int
-	Added     int
-	Modified  int
-	Deleted   int
-	Unchanged int
-	Errors    int
+	Scanned         int
+	Added           int
+	Modified        int
+	Deleted         int
+	Unchanged       int
+	Errors          int
+	BytesPlaintext  int64
+	BytesEncrypted  int64
+	Sessions        SessionStats
+	Elapsed         time.Duration
 }
 
 // HasChanges returns true if the seal produced any modifications worth committing.
@@ -28,6 +43,8 @@ func (s SealStats) HasChanges() bool {
 	return s.Added > 0 || s.Modified > 0 || s.Deleted > 0
 }
 
+// String returns a compact single-line summary suitable for commit messages.
+// Multiline() is the right choice for terminal display.
 func (s SealStats) String() string {
 	if s.Deleted > 0 {
 		return fmt.Sprintf("scanned %d files: %d new, %d modified, %d deleted, %d unchanged",
@@ -37,15 +54,41 @@ func (s SealStats) String() string {
 		s.Scanned, s.Added, s.Modified, s.Unchanged)
 }
 
-// UnsealStats tracks what happened during an unseal operation.
-type UnsealStats struct {
-	Total     int
-	Restored  int
-	Unchanged int
-	Deleted   int
-	Errors    int
+// Multiline returns a 2–3 line summary for sync display: scan counters,
+// data volume + elapsed, and session activity (when any sessions tracked).
+// Each line is prefixed with the given indent.
+func (s SealStats) Multiline(indent string) string {
+	var b strings.Builder
+	b.WriteString(indent)
+	b.WriteString(s.String())
+	if s.BytesPlaintext > 0 || s.BytesEncrypted > 0 {
+		b.WriteByte('\n')
+		b.WriteString(indent)
+		fmt.Fprintf(&b, "%s plaintext → %s encrypted (%s)",
+			FormatSize(s.BytesPlaintext), FormatSize(s.BytesEncrypted), formatElapsed(s.Elapsed))
+	}
+	if s.Sessions.Tracked > 0 {
+		b.WriteByte('\n')
+		b.WriteString(indent)
+		fmt.Fprintf(&b, "%d sessions tracked, %d new, %d updated since last sync",
+			s.Sessions.Tracked, s.Sessions.New, s.Sessions.Updated)
+	}
+	return b.String()
 }
 
+// UnsealStats tracks what happened during an unseal operation.
+type UnsealStats struct {
+	Total           int
+	Restored        int
+	Unchanged       int
+	Deleted         int
+	Errors          int
+	BytesDecrypted  int64
+	Merges          merge.Aggregate
+	Elapsed         time.Duration
+}
+
+// String returns a compact single-line summary.
 func (s UnsealStats) String() string {
 	if s.Deleted > 0 {
 		return fmt.Sprintf("%d files: %d restored, %d unchanged, %d deleted",
@@ -55,11 +98,45 @@ func (s UnsealStats) String() string {
 		s.Total, s.Restored, s.Unchanged)
 }
 
+// Multiline returns the single-line summary plus an optional merge-activity
+// line when the preceding pull invoked the merge driver.
+func (s UnsealStats) Multiline(indent string) string {
+	var b strings.Builder
+	b.WriteString(indent)
+	b.WriteString(s.String())
+	if s.BytesDecrypted > 0 {
+		fmt.Fprintf(&b, " (%s plaintext, %s)", FormatSize(s.BytesDecrypted), formatElapsed(s.Elapsed))
+	}
+	if s.Merges.FilesMerged > 0 {
+		b.WriteByte('\n')
+		b.WriteString(indent)
+		fmt.Fprintf(&b, "merged %d files (%d dup lines removed, %d sessions deduped)",
+			s.Merges.FilesMerged, s.Merges.LinesDeduped, s.Merges.SessionsDeduped)
+	}
+	return b.String()
+}
+
+// formatElapsed prints a duration with one significant fractional digit for
+// sub-minute durations ("1.4s"), and a coarser format above that.
+func formatElapsed(d time.Duration) string {
+	if d <= 0 {
+		return "0s"
+	}
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	return d.Round(time.Second).String()
+}
+
 // ProgressFunc is called during long operations to report progress.
 type ProgressFunc func(current, total int, path string)
 
 // Seal encrypts changed files from claudeDir into the seal store.
 func Seal(cfg *config.Config, recipient age.Recipient, verbose bool, progress ProgressFunc) (SealStats, error) {
+	start := time.Now()
 	var stats SealStats
 	sealDir := cfg.Seal.SealDir
 
@@ -68,15 +145,24 @@ func Seal(cfg *config.Config, recipient age.Recipient, verbose bool, progress Pr
 		return stats, fmt.Errorf("initializing object store: %w", err)
 	}
 
-	// Load existing manifest (may be nil on first seal)
+	// Load existing manifest (may be nil on first seal). Snapshot the prior
+	// file entries so we can compute session deltas without paying for a
+	// second pass after the seal mutates the manifest in place.
 	manifest, err := LoadManifest(sealDir)
 	if err != nil {
 		return stats, fmt.Errorf("loading manifest: %w", err)
 	}
+	prior := map[string]FileEntry{}
 	if manifest == nil {
 		manifest = NewManifest(cfg.Seal.DeviceID)
+	} else {
+		maps.Copy(prior, manifest.Files)
 	}
 	manifest.DeviceID = cfg.Seal.DeviceID
+
+	// Active session IDs (PID-alive). Empty when the sessions dir is absent
+	// (e.g. tests) — falls back to path-based completion semantics.
+	activeSessions := activeSessionIDs(cfg.Seal.ClaudeDir)
 
 	// Scan files
 	files, err := ScanFiles(cfg.Seal.ClaudeDir, cfg.Include.Patterns, cfg.Exclude.Patterns)
@@ -132,6 +218,8 @@ func Seal(cfg *config.Config, recipient age.Recipient, verbose bool, progress Pr
 		} else {
 			stats.Added++
 		}
+		stats.BytesPlaintext += f.Size
+		stats.BytesEncrypted += int64(len(encrypted))
 
 		if verbose {
 			action := "new"
@@ -151,13 +239,13 @@ func Seal(cfg *config.Config, recipient age.Recipient, verbose bool, progress Pr
 		}
 
 		manifest.Files[f.RelPath] = FileEntry{
-			ContentHash:    hash,
-			SizePlaintext:  f.Size,
-			SizeEncrypted:  int64(len(encrypted)),
-			Mtime:          time.UnixMilli(f.ModTimeMs).UTC().Format(time.RFC3339),
-			MergeStrategy:  ResolveMergeStrategy(f.RelPath, cfg.Merge),
-			JSONLLineCount: lineCount,
-			SessionComplete: isSessionComplete(f.RelPath),
+			ContentHash:     hash,
+			SizePlaintext:   f.Size,
+			SizeEncrypted:   int64(len(encrypted)),
+			Mtime:           time.UnixMilli(f.ModTimeMs).UTC().Format(time.RFC3339),
+			MergeStrategy:   ResolveMergeStrategy(f.RelPath, cfg.Merge),
+			JSONLLineCount:  lineCount,
+			SessionComplete: isSessionCompleteFor(f.RelPath, activeSessions),
 		}
 	}
 
@@ -172,18 +260,60 @@ func Seal(cfg *config.Config, recipient age.Recipient, verbose bool, progress Pr
 		}
 	}
 
+	// Tally session activity against the prior manifest. "Updated" counts
+	// session JSONLs whose JSONLLineCount grew since the previous seal —
+	// the most reliable signal short of consulting live process state.
+	for path, entry := range manifest.Files {
+		if !isSessionPath(path) {
+			continue
+		}
+		stats.Sessions.Tracked++
+		priorEntry, ok := prior[path]
+		if !ok {
+			stats.Sessions.New++
+			continue
+		}
+		if entry.JSONLLineCount > priorEntry.JSONLLineCount {
+			stats.Sessions.Updated++
+		}
+	}
+
 	// Save manifest
 	if err := manifest.Save(sealDir); err != nil {
 		return stats, fmt.Errorf("saving manifest: %w", err)
 	}
 
+	stats.Elapsed = time.Since(start)
 	return stats, nil
+}
+
+// activeSessionIDs returns the set of session UUIDs currently associated
+// with live processes. Failure to enumerate returns an empty set so seal
+// falls back to path-based completion (the historical behavior).
+func activeSessionIDs(claudeDir string) map[string]bool {
+	active := map[string]bool{}
+	sessions, err := session.DetectActive(claudeDir)
+	if err != nil {
+		return active
+	}
+	for _, s := range sessions {
+		if s.SessionID != "" {
+			active[s.SessionID] = true
+		}
+	}
+	return active
+}
+
+// isSessionPath matches the on-disk shape of a Claude session transcript.
+func isSessionPath(relPath string) bool {
+	return strings.HasPrefix(relPath, "projects/") && strings.HasSuffix(relPath, ".jsonl")
 }
 
 // Unseal decrypts seal contents back to claudeDir and removes managed
 // files not in the manifest. The manifest is the source of truth.
-func Unseal(cfg *config.Config, identity age.Identity, verbose bool, progress ProgressFunc) (UnsealStats, error) {
-	var stats UnsealStats
+func Unseal(cfg *config.Config, identity age.Identity, verbose bool, progress ProgressFunc) (stats UnsealStats, err error) {
+	start := time.Now()
+	defer func() { stats.Elapsed = time.Since(start) }()
 	sealDir := cfg.Seal.SealDir
 
 	store := NewObjectStore(sealDir)
@@ -249,6 +379,7 @@ func Unseal(cfg *config.Config, identity age.Identity, verbose bool, progress Pr
 			fmt.Printf("  [restore] %s (%s)\n", relPath, FormatSize(entry.SizePlaintext))
 		}
 		stats.Restored++
+		stats.BytesDecrypted += int64(len(plaintext))
 	}
 
 	// Delete managed files not in the manifest. The manifest is the source
@@ -452,11 +583,21 @@ func patternSpecificity(pattern string) string {
 	return fmt.Sprintf("%02d:%02d:%s", total, len(segs), pattern)
 }
 
-// isSessionComplete determines if a session JSONL file is likely complete.
-// Session files under projects/ with UUID-like names are complete if they exist
-// (active sessions are still being written to, but we check PIDs elsewhere).
-func isSessionComplete(relPath string) bool {
-	return strings.HasPrefix(relPath, "projects/") && strings.HasSuffix(relPath, ".jsonl")
+// isSessionCompleteFor determines whether a session JSONL file looks
+// complete. A session is "complete" iff it lives under projects/, ends in
+// .jsonl, and its UUID is not in the active set. An empty active set means
+// caller couldn't enumerate live sessions, in which case we fall back to
+// the historical path-based heuristic ("any matching path is complete").
+func isSessionCompleteFor(relPath string, active map[string]bool) bool {
+	if !isSessionPath(relPath) {
+		return false
+	}
+	if len(active) == 0 {
+		return true
+	}
+	base := filepath.Base(relPath)
+	uuid := strings.TrimSuffix(base, ".jsonl")
+	return !active[uuid]
 }
 
 // RepairResult describes the outcome of a seal store integrity check.
@@ -554,6 +695,11 @@ func Repair(cfg *config.Config, identity age.Identity, deleteOrphans bool, verbo
 
 	store := NewObjectStore(cfg.Seal.SealDir)
 
+	// Mirror Seal's PID-aware completion check so a Repair doesn't
+	// silently flip SessionComplete=true on currently-active session
+	// transcripts.
+	activeSessions := activeSessionIDs(cfg.Seal.ClaudeDir)
+
 	// Track old hashes that get superseded during repair so we can
 	// include them in orphan deletion (they become orphaned only after
 	// the manifest is updated with new hashes).
@@ -599,7 +745,7 @@ func Repair(cfg *config.Config, identity age.Identity, deleteOrphans bool, verbo
 				entry.JSONLLineCount++
 			}
 		}
-		entry.SessionComplete = isSessionComplete(path)
+		entry.SessionComplete = isSessionCompleteFor(path, activeSessions)
 		manifest.Files[path] = entry
 
 		result.Fixed++

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -198,6 +198,75 @@ func TestUnsealDeletesRemovedFiles(t *testing.T) {
 	}
 }
 
+// TestSealPopulatesByteCountersAndSessionTracked verifies the new
+// fields surfaced in the sync output: bytes processed and session
+// JSONL counts. Both depend on the per-file FileEntry data we already
+// gather — these assertions pin that they reach SealStats.
+func TestSealPopulatesByteCountersAndSessionTracked(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+
+	stats, err := Seal(cfg, identity.Recipient(), false, nil)
+	if err != nil {
+		t.Fatalf("Seal() error: %v", err)
+	}
+	if stats.BytesPlaintext <= 0 {
+		t.Errorf("BytesPlaintext should be > 0 after first seal, got %d", stats.BytesPlaintext)
+	}
+	if stats.BytesEncrypted <= 0 {
+		t.Errorf("BytesEncrypted should be > 0 after first seal, got %d", stats.BytesEncrypted)
+	}
+	// setupTestDir creates two session JSONLs under projects/proj-a/.
+	if stats.Sessions.Tracked < 2 {
+		t.Errorf("Sessions.Tracked: want >= 2 from test fixture, got %d", stats.Sessions.Tracked)
+	}
+	if stats.Sessions.New != stats.Sessions.Tracked {
+		t.Errorf("Sessions.New on first seal should equal Tracked (%d), got %d",
+			stats.Sessions.Tracked, stats.Sessions.New)
+	}
+	if stats.Elapsed <= 0 {
+		t.Errorf("Elapsed should be set, got %v", stats.Elapsed)
+	}
+}
+
+// TestSealCountsUpdatedSessions exercises the "Sessions.Updated" counter:
+// growing an existing session JSONL between two seals should show up as
+// exactly one update.
+func TestSealCountsUpdatedSessions(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+
+	if _, err := Seal(cfg, identity.Recipient(), false, nil); err != nil {
+		t.Fatalf("initial seal: %v", err)
+	}
+
+	// Append a second JSONL record to an existing session transcript.
+	sessionPath := filepath.Join(claudeDir, "projects", "proj-a", "abc123.jsonl")
+	f, err := os.OpenFile(sessionPath, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("open session for append: %v", err)
+	}
+	f.WriteString("\n" + `{"type":"assistant","content":"hi"}` + "\n")
+	f.Close()
+
+	stats, err := Seal(cfg, identity.Recipient(), false, nil)
+	if err != nil {
+		t.Fatalf("second seal: %v", err)
+	}
+	if stats.Sessions.New != 0 {
+		t.Errorf("Sessions.New: want 0 on incremental seal, got %d", stats.Sessions.New)
+	}
+	if stats.Sessions.Updated != 1 {
+		t.Errorf("Sessions.Updated: want 1 (the appended file), got %d", stats.Sessions.Updated)
+	}
+}
+
 func TestUnsealDoesNotDeleteUnmanagedFiles(t *testing.T) {
 	claudeDir := setupTestDir(t)
 	sealDir := t.TempDir()


### PR DESCRIPTION
🎯 **What:** Fixed an argument injection vulnerability in `Git.RemoteRemove` and other methods taking positional arguments.
⚠️ **Risk:** User-provided inputs (like remote names or branch names) starting with hyphens (e.g., `--extcmd=...`) could be parsed by the git binary as command line options, leading to potential command execution or unintended option parsing.
🛡️ **Solution:** Added the `--` end-of-options separator to git wrapper commands in `internal/gitops/git.go`, ensuring that all user inputs following `--` are treated strictly as positional arguments. Audited and fixed similar commands (`Push`, `Fetch`, `Pull`, `Merge`, etc.). Also added a unit test to verify the fix.

---
*PR created automatically by Jules for task [5208392260161733666](https://jules.google.com/task/5208392260161733666) started by @coredipper*