### PR TITLE
⚡ Bolt: Use hex.EncodeToString instead of fmt.Sprintf for hash encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 enclaude
 dist/
 *.key
+.jules/

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## $(date +%Y-%m-%d) - Hash Encoding Performance
+**Learning:** `hex.EncodeToString(hash[:])` is approximately 2x faster and has fewer memory allocations compared to `fmt.Sprintf("%x", hash)`. This is a valuable micro-optimization for hot paths that involve hashing large numbers of files or lines.
+**Action:** Default to `hex.EncodeToString` instead of `fmt.Sprintf` for formatting byte arrays as hexadecimal strings.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## $(date +%Y-%m-%d) - Hash Encoding Performance
-**Learning:** `hex.EncodeToString(hash[:])` is approximately 2x faster and has fewer memory allocations compared to `fmt.Sprintf("%x", hash)`. This is a valuable micro-optimization for hot paths that involve hashing large numbers of files or lines.
-**Action:** Default to `hex.EncodeToString` instead of `fmt.Sprintf` for formatting byte arrays as hexadecimal strings.

--- a/internal/merge/jsonl.go
+++ b/internal/merge/jsonl.go
@@ -2,6 +2,7 @@ package merge
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -130,17 +131,20 @@ func hashNormalized(line string) string {
 	if err := json.Unmarshal([]byte(line), &obj); err != nil {
 		// Not valid JSON — hash the raw line
 		h := sha256.Sum256([]byte(line))
-		return fmt.Sprintf("%x", h)
+		// Optimize hash encoding: hex.EncodeToString is ~2x faster and allocates less than fmt.Sprintf("%x")
+		return hex.EncodeToString(h[:])
 	}
 
 	normalized, err := json.Marshal(obj)
 	if err != nil {
 		h := sha256.Sum256([]byte(line))
-		return fmt.Sprintf("%x", h)
+		// Optimize hash encoding: hex.EncodeToString is ~2x faster and allocates less than fmt.Sprintf("%x")
+		return hex.EncodeToString(h[:])
 	}
 
 	h := sha256.Sum256(normalized)
-	return fmt.Sprintf("%x", h)
+	// Optimize hash encoding: hex.EncodeToString is ~2x faster and allocates less than fmt.Sprintf("%x")
+	return hex.EncodeToString(h[:])
 }
 
 // extractTimestamp pulls the "timestamp" field from a JSON line for sorting.

--- a/internal/merge/jsonl.go
+++ b/internal/merge/jsonl.go
@@ -131,19 +131,16 @@ func hashNormalized(line string) string {
 	if err := json.Unmarshal([]byte(line), &obj); err != nil {
 		// Not valid JSON — hash the raw line
 		h := sha256.Sum256([]byte(line))
-		// Optimize hash encoding: hex.EncodeToString is ~2x faster and allocates less than fmt.Sprintf("%x")
 		return hex.EncodeToString(h[:])
 	}
 
 	normalized, err := json.Marshal(obj)
 	if err != nil {
 		h := sha256.Sum256([]byte(line))
-		// Optimize hash encoding: hex.EncodeToString is ~2x faster and allocates less than fmt.Sprintf("%x")
 		return hex.EncodeToString(h[:])
 	}
 
 	h := sha256.Sum256(normalized)
-	// Optimize hash encoding: hex.EncodeToString is ~2x faster and allocates less than fmt.Sprintf("%x")
 	return hex.EncodeToString(h[:])
 }
 

--- a/internal/store/objects.go
+++ b/internal/store/objects.go
@@ -22,7 +22,6 @@ func NewObjectStore(sealDir string) *ObjectStore {
 // ContentHash computes the SHA-256 hash of plaintext content.
 func ContentHash(data []byte) string {
 	h := sha256.Sum256(data)
-	// Optimize hash encoding: hex.EncodeToString is ~2x faster and allocates less than fmt.Sprintf("%x")
 	return hex.EncodeToString(h[:])
 }
 

--- a/internal/store/objects.go
+++ b/internal/store/objects.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,7 +22,8 @@ func NewObjectStore(sealDir string) *ObjectStore {
 // ContentHash computes the SHA-256 hash of plaintext content.
 func ContentHash(data []byte) string {
 	h := sha256.Sum256(data)
-	return fmt.Sprintf("%x", h)
+	// Optimize hash encoding: hex.EncodeToString is ~2x faster and allocates less than fmt.Sprintf("%x")
+	return hex.EncodeToString(h[:])
 }
 
 // ObjectPath returns the filesystem path for a given content hash.


### PR DESCRIPTION
💡 What: Replaced `fmt.Sprintf("%x", h)` with `hex.EncodeToString(h[:])` for formatting SHA-256 hashes in `internal/merge/jsonl.go` and `internal/store/objects.go`.
🎯 Why: `fmt.Sprintf` uses reflection to determine the type of the arguments, which introduces CPU overhead and memory allocations. `hex.EncodeToString` directly operates on the byte slice, avoiding reflection and significantly improving performance, which is especially important for hot paths like hashing every line of a JSONL file.
📊 Impact: Expected to run roughly 2x faster and use less memory per hash encoded.
🔬 Measurement: Verify by running benchmarks comparing `fmt.Sprintf("%x", h)` and `hex.EncodeToString(h[:])`.

---
*PR created automatically by Jules for task [17740070845097476559](https://jules.google.com/task/17740070845097476559) started by @coredipper*