### PR TITLE
🔒 Close ext:: bypass via RemoteSetURL

### DIFF
--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -85,13 +85,23 @@ func (g *Git) MergeAbort() error {
 	return err
 }
 
-// RemoteAdd adds a git remote.
-func (g *Git) RemoteAdd(name, url string) error {
-	// The ext:: transport runs an arbitrary command on fetch/push, so a
-	// remote URL using it is a code-execution vector even when passed as a
-	// safe positional — the -- separator above cannot neutralize it.
+// rejectUnsafeRemoteURL blocks remote URLs whose transport executes an
+// arbitrary command. ext:: runs its argument as a shell command on every
+// fetch/push, so it is a code-execution vector regardless of how safely
+// the URL is passed as a positional — the -- separator cannot neutralize
+// a valid-but-malicious positional. Called from every path that records a
+// remote URL (add and set-url) so the guard can't be bypassed by editing.
+func rejectUnsafeRemoteURL(url string) error {
 	if strings.HasPrefix(url, "ext::") {
 		return fmt.Errorf("refusing remote with ext:: URL (arbitrary command execution transport): %s", url)
+	}
+	return nil
+}
+
+// RemoteAdd adds a git remote.
+func (g *Git) RemoteAdd(name, url string) error {
+	if err := rejectUnsafeRemoteURL(url); err != nil {
+		return err
 	}
 	_, err := g.run("remote", "add", "--", name, url)
 	return err
@@ -110,6 +120,9 @@ func (g *Git) RemoteRemove(name string) error {
 
 // RemoteSetURL updates the URL of an existing git remote.
 func (g *Git) RemoteSetURL(name, url string) error {
+	if err := rejectUnsafeRemoteURL(url); err != nil {
+		return err
+	}
 	_, err := g.run("remote", "set-url", "--", name, url)
 	return err
 }

--- a/internal/gitops/git_test.go
+++ b/internal/gitops/git_test.go
@@ -79,29 +79,55 @@ func TestGitOptionInjectionMitigation(t *testing.T) {
 	})
 }
 
-// TestRemoteAddRejectsExtTransport guards the ext:: git transport, which
+// TestRemoteRejectsExtTransport guards the ext:: git transport, which
 // executes an arbitrary command on fetch/push. The -- option separator
 // cannot neutralize this because the URL is a valid positional, not an
-// option — so RemoteAdd must reject it explicitly.
-func TestRemoteAddRejectsExtTransport(t *testing.T) {
-	g := New(t.TempDir())
-	if err := g.Init(); err != nil {
-		t.Fatalf("Init failed: %v", err)
-	}
+// option. Every path that records a remote URL must reject it — guarding
+// only RemoteAdd would leave the set-url edit path as a bypass (add a
+// benign remote, then point it at ext:: afterwards).
+func TestRemoteRejectsExtTransport(t *testing.T) {
+	const extURL = "ext::sh -c 'touch pwned'"
 
-	err := g.RemoteAdd("evil", "ext::sh -c 'touch pwned'")
-	if err == nil {
-		t.Fatal("RemoteAdd accepted an ext:: URL; expected rejection")
-	}
-	if !strings.Contains(err.Error(), "ext::") {
-		t.Errorf("rejection error should mention ext::, got: %v", err)
-	}
+	t.Run("RemoteAdd", func(t *testing.T) {
+		g := New(t.TempDir())
+		if err := g.Init(); err != nil {
+			t.Fatalf("Init failed: %v", err)
+		}
+		err := g.RemoteAdd("evil", extURL)
+		if err == nil {
+			t.Fatal("RemoteAdd accepted an ext:: URL; expected rejection")
+		}
+		if !strings.Contains(err.Error(), "ext::") {
+			t.Errorf("rejection error should mention ext::, got: %v", err)
+		}
+		// A benign URL must still be accepted (records config only, no
+		// network), so the guard doesn't over-reject.
+		if err := g.RemoteAdd("origin", "https://example.invalid/r.git"); err != nil {
+			t.Fatalf("RemoteAdd rejected a benign https URL: %v", err)
+		}
+	})
 
-	// A benign URL must still be accepted (remote add records config only,
-	// no network), so the guard doesn't over-reject.
-	if err := g.RemoteAdd("origin", "https://example.invalid/r.git"); err != nil {
-		t.Fatalf("RemoteAdd rejected a benign https URL: %v", err)
-	}
+	t.Run("RemoteSetURL bypass is closed", func(t *testing.T) {
+		g := New(t.TempDir())
+		if err := g.Init(); err != nil {
+			t.Fatalf("Init failed: %v", err)
+		}
+		// Bypass attempt: add a benign remote, then edit it to ext::.
+		if err := g.RemoteAdd("origin", "https://example.invalid/r.git"); err != nil {
+			t.Fatalf("benign RemoteAdd failed: %v", err)
+		}
+		err := g.RemoteSetURL("origin", extURL)
+		if err == nil {
+			t.Fatal("RemoteSetURL accepted an ext:: URL; the add-then-edit bypass is open")
+		}
+		if !strings.Contains(err.Error(), "ext::") {
+			t.Errorf("rejection error should mention ext::, got: %v", err)
+		}
+		// A benign re-point must still work.
+		if err := g.RemoteSetURL("origin", "https://example.invalid/r2.git"); err != nil {
+			t.Fatalf("RemoteSetURL rejected a benign https URL: %v", err)
+		}
+	})
 }
 
 func TestConfigMergeDriverQuoting(t *testing.T) {


### PR DESCRIPTION
## Summary
- Follow-up to #22's `ext::` guard, which only covered `RemoteAdd`. roborev job #994 (High) caught the bypass: add a benign remote, then `git remote set-url <name> ext::sh -c '...'` — fetch/push then uses the arbitrary-command transport.
- Extracts a shared `rejectUnsafeRemoteURL` helper and calls it from **both** `RemoteAdd` and `RemoteSetURL`, so the guard can't be sidestepped through the edit path.
- `TestRemoteRejectsExtTransport` now has an explicit "add benign remote, then set-url to ext::" bypass subtest, plus benign-URL checks so the guard doesn't over-reject.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1` (full suite green)
- [x] `TestRemoteRejectsExtTransport/RemoteAdd` and `/RemoteSetURL_bypass_is_closed` pass
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)