### PR TITLE
fix: restore createKeyBackup extraction reverted by #18 merge

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -71,24 +71,8 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	// 4. Create passphrase-encrypted backup
-	fmt.Println()
-	passphrase, err := ui.ReadPassphraseOptional("Enter backup passphrase (for key recovery, blank to skip): ")
-	if err != nil {
-		return fmt.Errorf("reading backup passphrase: %w", err)
-	}
-
-	if passphrase != "" {
-		backup, err := crypto.EncryptWithPassphrase([]byte(identity.String()), passphrase)
-		if err != nil {
-			return fmt.Errorf("creating key backup: %w", err)
-		}
-		backupPath := filepath.Join(sealDir, "key.age.backup")
-		if err := os.WriteFile(backupPath, backup, 0600); err != nil {
-			return fmt.Errorf("writing key backup: %w", err)
-		}
-		fmt.Println("  Key backup saved.")
-	} else {
-		fmt.Println("  Skipping backup (no passphrase entered).")
+	if err := createKeyBackup(sealDir, identity.String()); err != nil {
+		return err
 	}
 
 	// 5. Write default config
@@ -208,6 +192,30 @@ enclaude pull          # pull and decrypt latest
 enclaude status        # show unsealed changes not yet sealed
 {FENCE}
 `
+
+func createKeyBackup(sealDir, secretKey string) error {
+	fmt.Println()
+	passphrase, err := ui.ReadPassphraseOptional("Enter backup passphrase (for key recovery, blank to skip): ")
+	if err != nil {
+		return fmt.Errorf("reading backup passphrase: %w", err)
+	}
+
+	if passphrase != "" {
+		backup, err := crypto.EncryptWithPassphrase([]byte(secretKey), passphrase)
+		if err != nil {
+			return fmt.Errorf("creating key backup: %w", err)
+		}
+		backupPath := filepath.Join(sealDir, "key.age.backup")
+		if err := os.WriteFile(backupPath, backup, 0600); err != nil {
+			return fmt.Errorf("writing key backup: %w", err)
+		}
+		fmt.Println("  Key backup saved.")
+	} else {
+		fmt.Println("  Skipping backup (no passphrase entered).")
+	}
+
+	return nil
+}
 
 func buildReadme(publicKey, deviceID string) string {
 	return strings.NewReplacer(


### PR DESCRIPTION
## Summary
- PR #16 extracted the backup-passphrase logic out of `runInit` into a `createKeyBackup(sealDir, secretKey string)` helper. #18's branch predated #16, and its `"Merge branch 'main'"` commit (`90a400b`) resolved the `cmd/init.go` conflict by keeping the pre-#16 inline block — silently reverting #16. That revert reached `main` when #18 was admin-merged (`b4f9c92`).
- This restores `cmd/init.go` to its post-#16 state. Verified `90a400b` is the **only** commit to have touched `cmd/init.go` since #16 merged (`52e3cc8`), so this is an exact restore — no other init.go work is lost.
- Pure refactor, **no behavior change** (the inline block and the helper are functionally identical).

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1` (full suite green)
- [x] Staged diff confirmed to be exactly the inverse of the `90a400b` revert (helper + call site restored, inline block removed)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)