### PR TITLE
🛡️ Sentinel: [HIGH] Fix Git flag injection via dashed remote names and URLs

### DIFF
--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -206,11 +206,26 @@ func rejectUnsafeRemoteURL(url string) error {
 	if strings.HasPrefix(url, "ext::") {
 		return fmt.Errorf("refusing remote with ext:: URL (arbitrary command execution transport): %s", url)
 	}
+	if strings.HasPrefix(url, "-") {
+		return fmt.Errorf("refusing remote URL starting with dash (flag injection risk): %s", url)
+	}
+	return nil
+}
+
+// rejectUnsafeRemoteName blocks remote names that start with a dash to
+// prevent flag injection vulnerabilities when passed to git commands.
+func rejectUnsafeRemoteName(name string) error {
+	if strings.HasPrefix(name, "-") {
+		return fmt.Errorf("refusing remote name starting with dash (flag injection risk): %s", name)
+	}
 	return nil
 }
 
 // RemoteAdd adds a git remote.
 func (g *Git) RemoteAdd(name, url string) error {
+	if err := rejectUnsafeRemoteName(name); err != nil {
+		return err
+	}
 	if err := rejectUnsafeRemoteURL(url); err != nil {
 		return err
 	}
@@ -225,12 +240,18 @@ func (g *Git) RemoteList() (string, error) {
 
 // RemoteRemove removes a git remote.
 func (g *Git) RemoteRemove(name string) error {
+	if err := rejectUnsafeRemoteName(name); err != nil {
+		return err
+	}
 	_, err := g.run("remote", "remove", "--", name)
 	return err
 }
 
 // RemoteSetURL updates the URL of an existing git remote.
 func (g *Git) RemoteSetURL(name, url string) error {
+	if err := rejectUnsafeRemoteName(name); err != nil {
+		return err
+	}
 	if err := rejectUnsafeRemoteURL(url); err != nil {
 		return err
 	}

--- a/internal/gitops/git_test.go
+++ b/internal/gitops/git_test.go
@@ -64,17 +64,11 @@ func TestGitOptionInjectionMitigation(t *testing.T) {
 	// Test remote with dashed name
 	t.Run("RemoteAdd dashed name", func(t *testing.T) {
 		err := baseGit.RemoteAdd("--upload-pack=exploit", "http://example.com")
-		if err != nil {
-			t.Fatalf("RemoteAdd failed to create remote with dashed name: %v", err)
+		if err == nil {
+			t.Fatalf("RemoteAdd created remote with dashed name, expected rejection")
 		}
-
-		// Verify remote was created with the literal dashed name
-		out, err := baseGit.RemoteList()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !strings.Contains(out, "--upload-pack=exploit") {
-			t.Errorf("Expected remote to be created with dashed name, got: %q", out)
+		if !strings.Contains(err.Error(), "dash") {
+			t.Errorf("Expected rejection due to dash, got: %v", err)
 		}
 	})
 }

--- a/internal/gitops/git_test.go
+++ b/internal/gitops/git_test.go
@@ -124,6 +124,91 @@ func TestRemoteRejectsExtTransport(t *testing.T) {
 	})
 }
 
+// TestRemoteRejectsDashPrefixedArgs covers the dash-prefix input guards: a
+// remote name or URL beginning with "-" is refused before reaching git, so
+// it can't be mistaken for a flag even on a git build that mishandles the --
+// separator. Mirrors the ext:: coverage — every recording path is checked,
+// plus benign inputs to prove the guard doesn't over-reject.
+func TestRemoteRejectsDashPrefixedArgs(t *testing.T) {
+	const dashName = "--upload-pack=exploit"
+	const dashURL = "--upload-pack=exploit"
+	const benignURL = "https://example.invalid/r.git"
+
+	t.Run("RemoteAdd rejects dashed name", func(t *testing.T) {
+		g := New(t.TempDir())
+		if err := g.Init(); err != nil {
+			t.Fatalf("Init failed: %v", err)
+		}
+		err := g.RemoteAdd(dashName, benignURL)
+		if err == nil {
+			t.Fatal("RemoteAdd accepted a dash-prefixed name; expected rejection")
+		}
+		if !strings.Contains(err.Error(), "dash") {
+			t.Errorf("rejection error should mention dash, got: %v", err)
+		}
+	})
+
+	t.Run("RemoteAdd rejects dashed URL", func(t *testing.T) {
+		g := New(t.TempDir())
+		if err := g.Init(); err != nil {
+			t.Fatalf("Init failed: %v", err)
+		}
+		err := g.RemoteAdd("origin", dashURL)
+		if err == nil {
+			t.Fatal("RemoteAdd accepted a dash-prefixed URL; expected rejection")
+		}
+		if !strings.Contains(err.Error(), "dash") {
+			t.Errorf("rejection error should mention dash, got: %v", err)
+		}
+	})
+
+	t.Run("RemoteSetURL rejects dashed name and URL", func(t *testing.T) {
+		g := New(t.TempDir())
+		if err := g.Init(); err != nil {
+			t.Fatalf("Init failed: %v", err)
+		}
+		if err := g.RemoteAdd("origin", benignURL); err != nil {
+			t.Fatalf("benign RemoteAdd failed: %v", err)
+		}
+		if err := g.RemoteSetURL(dashName, benignURL); err == nil {
+			t.Fatal("RemoteSetURL accepted a dash-prefixed name; expected rejection")
+		}
+		if err := g.RemoteSetURL("origin", dashURL); err == nil {
+			t.Fatal("RemoteSetURL accepted a dash-prefixed URL; expected rejection")
+		}
+	})
+
+	t.Run("RemoteRemove rejects dashed name", func(t *testing.T) {
+		g := New(t.TempDir())
+		if err := g.Init(); err != nil {
+			t.Fatalf("Init failed: %v", err)
+		}
+		err := g.RemoteRemove(dashName)
+		if err == nil {
+			t.Fatal("RemoteRemove accepted a dash-prefixed name; expected rejection")
+		}
+		if !strings.Contains(err.Error(), "dash") {
+			t.Errorf("rejection error should mention dash, got: %v", err)
+		}
+	})
+
+	t.Run("benign name and URL still accepted", func(t *testing.T) {
+		g := New(t.TempDir())
+		if err := g.Init(); err != nil {
+			t.Fatalf("Init failed: %v", err)
+		}
+		if err := g.RemoteAdd("origin", benignURL); err != nil {
+			t.Fatalf("RemoteAdd rejected a benign remote: %v", err)
+		}
+		if err := g.RemoteSetURL("origin", "https://example.invalid/r2.git"); err != nil {
+			t.Fatalf("RemoteSetURL rejected a benign re-point: %v", err)
+		}
+		if err := g.RemoteRemove("origin"); err != nil {
+			t.Fatalf("RemoteRemove rejected a benign remote: %v", err)
+		}
+	})
+}
+
 func TestConfigMergeDriverQuoting(t *testing.T) {
 	tmp := t.TempDir()
 	g := New(tmp)


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Flag injection via positional arguments in Git commands. A user-provided remote name or URL starting with `-` could be parsed as a git flag rather than a positional argument, despite the `--` separator.
🎯 **Impact:** Potential arbitrary command execution or unexpected behaviors by manipulating git command flags via manipulated remote names and URLs.
🔧 **Fix:** Introduced `rejectUnsafeRemoteName` and augmented `rejectUnsafeRemoteURL` to explicitly block and reject any inputs that start with a `-` (hyphen) in `internal/gitops/git.go`. Test cases have been updated to assert rejection.
✅ **Verification:** Ran the full test suite (`go test ./...`) focusing particularly on the `internal/gitops` package `TestGitOptionInjectionMitigation` test. Also ensured `gofmt` and `go vet` passes cleanly.

---
*PR created automatically by Jules for task [1133847918933097984](https://jules.google.com/task/1133847918933097984) started by @coredipper*