### PR TITLE
🛡️ Harden RemoteSetURL dash-guard test assertions

### DIFF
--- a/internal/gitops/git_test.go
+++ b/internal/gitops/git_test.go
@@ -170,11 +170,22 @@ func TestRemoteRejectsDashPrefixedArgs(t *testing.T) {
 		if err := g.RemoteAdd("origin", benignURL); err != nil {
 			t.Fatalf("benign RemoteAdd failed: %v", err)
 		}
-		if err := g.RemoteSetURL(dashName, benignURL); err == nil {
+		// Assert the guard fired (error mentions "dash") rather than git
+		// merely erroring because no remote named dashName exists — otherwise
+		// the name case would pass even with the guard removed.
+		err := g.RemoteSetURL(dashName, benignURL)
+		if err == nil {
 			t.Fatal("RemoteSetURL accepted a dash-prefixed name; expected rejection")
 		}
-		if err := g.RemoteSetURL("origin", dashURL); err == nil {
+		if !strings.Contains(err.Error(), "dash") {
+			t.Errorf("rejection error should mention dash, got: %v", err)
+		}
+		err = g.RemoteSetURL("origin", dashURL)
+		if err == nil {
 			t.Fatal("RemoteSetURL accepted a dash-prefixed URL; expected rejection")
+		}
+		if !strings.Contains(err.Error(), "dash") {
+			t.Errorf("rejection error should mention dash, got: %v", err)
 		}
 	})
 


### PR DESCRIPTION
Addresses roborev review job 1050 (LOW) on the now-merged #41 test commit.

**Finding:** the `RemoteSetURL` dash-prefixed subtests only asserted `err != nil`. The dashed-**name** case would pass even with the guard removed, because `git remote set-url -- --upload-pack=exploit …` errors anyway (no such remote exists) — so the test didn't prove the guard fired *before* reaching git.

**Fix:** assert the error contains `"dash"` for both the dashed name and URL `RemoteSetURL` inputs, matching what the `RemoteAdd`/`RemoteRemove` cases already do.

Test-only change; `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)