### PR TITLE
build: silence goreleaser archives.format deprecation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,7 @@ builds:
       - -X github.com/coredipper/enclaude/cmd.Version={{.Version}}
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: "enclaude_{{ .Os }}_{{ .Arch }}"
 
 checksum:


### PR DESCRIPTION
Switches `.goreleaser.yaml` from the deprecated scalar `archives.format: tar.gz` to the `archives.formats: [tar.gz]` list form (goreleaser v2). Resolves the deprecation warning emitted during the v0.7.3 release.

`goreleaser check` passes clean. Config-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)