### PR TITLE
🧪 Git: Add tests for Init function

### DIFF
--- a/internal/gitops/git_test.go
+++ b/internal/gitops/git_test.go
@@ -468,3 +468,58 @@ func TestGitFetch(t *testing.T) {
 		}
 	})
 }
+
+// TestGitInit covers Init: it creates the .git directory, is idempotent
+// when run twice on the same repo, and returns an error when the target
+// path is an existing file rather than a directory.
+func TestGitInit(t *testing.T) {
+	t.Run("HappyPath", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		g := New(tmpDir)
+		if err := g.Init(); err != nil {
+			t.Fatalf("Init failed: %v", err)
+		}
+
+		// Verify .git directory is created
+		gitDir := filepath.Join(tmpDir, ".git")
+		info, err := os.Stat(gitDir)
+		if err != nil {
+			t.Fatalf("Failed to stat .git directory: %v", err)
+		}
+		if !info.IsDir() {
+			t.Errorf("Expected .git to be a directory")
+		}
+	})
+
+	t.Run("Idempotency", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		g := New(tmpDir)
+		if err := g.Init(); err != nil {
+			t.Fatalf("First Init failed: %v", err)
+		}
+
+		// Second Init should also succeed
+		if err := g.Init(); err != nil {
+			t.Fatalf("Second Init failed, not idempotent: %v", err)
+		}
+	})
+
+	t.Run("ErrorCondition", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Create a file where the git repo root should be
+		// Wait, New(dir) doesn't take the .git folder, it takes the working directory.
+		// So to cause git init to fail, we can make the working directory itself a file.
+
+		filePath := filepath.Join(tmpDir, "repo-file")
+		if err := os.WriteFile(filePath, []byte("data"), 0644); err != nil {
+			t.Fatalf("Failed to create file: %v", err)
+		}
+
+		g := New(filePath)
+		err := g.Init()
+		if err == nil {
+			t.Fatal("Expected Init to fail when directory path is an existing file, but it succeeded")
+		}
+	})
+}


### PR DESCRIPTION
🎯 **What:** 
The `Init` method of the `Git` struct in `internal/gitops/git.go` did not have dedicated unit tests. This PR addresses that testing gap.

📊 **Coverage:**
Added testing for `Init` including:
- **Happy Path:** Initializes a new git repository in a temporary directory and verifies that the `.git` directory is created.
- **Idempotency:** Calls `Init` twice on the same repository and validates that the second call succeeds without error since `git init` is idempotent.
- **Error Condition:** Attempts to initialize a repository where a file exists at the expected git path, causing `git init` to fail and return the expected error.

✨ **Result:**
Increased test coverage for `internal/gitops`, specifically targeting repository initialization paths, ensuring `Init` properly surfaces git command errors and handles successful completions.

---
*PR created automatically by Jules for task [16683802544812624272](https://jules.google.com/task/16683802544812624272) started by @coredipper*