### PR TITLE
🧪 Add missing tests for internal/session/lock.go

### DIFF
--- a/internal/session/lock_test.go
+++ b/internal/session/lock_test.go
@@ -1,0 +1,88 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSealLock_Basic(t *testing.T) {
+	dir := t.TempDir()
+	lock1 := NewSealLock(dir)
+	lock2 := NewSealLock(dir)
+
+	// Acquire lock1
+	locked, err := lock1.Acquire(1 * time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error acquiring lock1: %v", err)
+	}
+	if !locked {
+		t.Fatal("expected to acquire lock1")
+	}
+
+	// Try to acquire lock2, should fail due to timeout
+	start := time.Now()
+	locked2, err := lock2.Acquire(500 * time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error when acquiring locked lock")
+	}
+	if !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+	if locked2 {
+		t.Fatal("expected not to acquire lock2")
+	}
+	elapsed := time.Since(start)
+	if elapsed < 500*time.Millisecond {
+		t.Fatalf("expected Acquire to block for at least timeout, blocked for %v", elapsed)
+	}
+
+	// Release lock1
+	if err := lock1.Release(); err != nil {
+		t.Fatalf("failed to release lock1: %v", err)
+	}
+
+	// Now lock2 should succeed
+	locked2, err = lock2.Acquire(1 * time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error acquiring lock2: %v", err)
+	}
+	if !locked2 {
+		t.Fatal("expected to acquire lock2")
+	}
+	lock2.Release()
+}
+
+func TestSealLock_ReleaseWithoutAcquire(t *testing.T) {
+	dir := t.TempDir()
+	lock := NewSealLock(dir)
+
+	err := lock.Release()
+	if err != nil {
+		t.Fatalf("unexpected error releasing unacquired lock: %v", err)
+	}
+}
+
+func TestSealLock_PermissionDenied(t *testing.T) {
+	dir := t.TempDir()
+
+	readOnlyDir := filepath.Join(dir, "readonly")
+	if err := os.Mkdir(readOnlyDir, 0555); err != nil {
+		t.Fatalf("failed to create readonly dir: %v", err)
+	}
+
+	lock := NewSealLock(readOnlyDir)
+
+	locked, err := lock.Acquire(1 * time.Second)
+	if locked {
+		t.Fatal("expected not to acquire lock in readonly directory")
+	}
+	if err == nil {
+		t.Fatal("expected an error due to permission denied")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/session/lock_test.go
+++ b/internal/session/lock_test.go
@@ -8,6 +8,9 @@ import (
 	"time"
 )
 
+// TestSealLock_Basic verifies a second SealLock.Acquire on the same dir
+// blocks until its timeout and fails with a deadline error while the first
+// holder is active, then succeeds once the first lock is released.
 func TestSealLock_Basic(t *testing.T) {
 	dir := t.TempDir()
 	lock1 := NewSealLock(dir)
@@ -55,6 +58,8 @@ func TestSealLock_Basic(t *testing.T) {
 	lock2.Release()
 }
 
+// TestSealLock_ReleaseWithoutAcquire verifies Release on a never-acquired
+// lock is a no-op and returns no error.
 func TestSealLock_ReleaseWithoutAcquire(t *testing.T) {
 	dir := t.TempDir()
 	lock := NewSealLock(dir)
@@ -65,6 +70,9 @@ func TestSealLock_ReleaseWithoutAcquire(t *testing.T) {
 	}
 }
 
+// TestSealLock_PermissionDenied verifies Acquire fails with a permission
+// error when the lock directory is read-only and the lock file cannot be
+// created.
 func TestSealLock_PermissionDenied(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
🎯 **What:** 
The `internal/session/lock.go` file was missing tests, creating a gap in testing for `SealLock`—a file-based locking mechanism using `flock`. Locking mechanisms can be tricky and error-prone due to concurrency or OS specifics, so dedicated testing is required.

📊 **Coverage:** 
- `TestSealLock_Basic`: Validates the standard acquire/release cycle, including testing timeout and blocking behavior when attempting to acquire a lock that is already held.
- `TestSealLock_ReleaseWithoutAcquire`: Verifies that releasing an unacquired lock returns without errors.
- `TestSealLock_PermissionDenied`: Asserts that `Acquire` returns the correct error and does not hang when directory permissions prevent creating the lock file.

✨ **Result:** 
Increased the overall test coverage and reliability of the `internal/session` package, specifically solidifying the `SealLock` functionality against concurrency and permission-related edge cases.

---
*PR created automatically by Jules for task [11848433592281466233](https://jules.google.com/task/11848433592281466233) started by @coredipper*