### PR TITLE
🧪 Add test for DefaultConfig

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -113,3 +113,72 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 		t.Errorf("merge strategies lost: got %d, want %d", len(loaded.Merge), len(orig.Merge))
 	}
 }
+
+func TestDefaultConfig(t *testing.T) {
+	claudeDir := "/mock/claude"
+	sealDir := "/mock/seal"
+
+	cfg := DefaultConfig(claudeDir, sealDir)
+
+	if cfg.Version != ConfigVersion {
+		t.Errorf("expected Version %d, got %d", ConfigVersion, cfg.Version)
+	}
+
+	if cfg.Seal.ClaudeDir != claudeDir {
+		t.Errorf("expected ClaudeDir %q, got %q", claudeDir, cfg.Seal.ClaudeDir)
+	}
+
+	if cfg.Seal.SealDir != sealDir {
+		t.Errorf("expected SealDir %q, got %q", sealDir, cfg.Seal.SealDir)
+	}
+
+	if cfg.Seal.DeviceID == "" {
+		t.Error("expected non-empty DeviceID")
+	}
+
+	if !cfg.Sync.AutoSealOnSessionEnd {
+		t.Error("expected AutoSealOnSessionEnd to be true")
+	}
+
+	if !cfg.Sync.AutoUnsealOnSessionStart {
+		t.Error("expected AutoUnsealOnSessionStart to be true")
+	}
+
+	if cfg.Sync.AutoPush {
+		t.Error("expected AutoPush to be false")
+	}
+
+	if cfg.Sync.AutoPull {
+		t.Error("expected AutoPull to be false")
+	}
+
+	if len(cfg.Include.Patterns) != 12 {
+		t.Errorf("expected 12 include patterns, got %d", len(cfg.Include.Patterns))
+	}
+
+	if len(cfg.Exclude.Patterns) != 17 {
+		t.Errorf("expected 17 exclude patterns, got %d", len(cfg.Exclude.Patterns))
+	}
+
+	expectedMerges := map[string]string{
+		"history.jsonl":                   "jsonl_dedup",
+		"projects/*/sessions-index.json":  "sessions_index",
+		"stats-cache.json":                "last_write_wins",
+		"settings.json":                   "last_write_wins",
+		"projects/*/*.jsonl":              "immutable",
+		"projects/*/subagents/**/*.jsonl": "immutable",
+		"projects/*/subagents/**/*.json":  "immutable",
+		"projects/*/memory/**":            "text_merge",
+		"**/*.md":                         "text_merge",
+	}
+
+	if len(cfg.Merge) != len(expectedMerges) {
+		t.Errorf("expected %d merge strategies, got %d", len(expectedMerges), len(cfg.Merge))
+	}
+
+	for k, v := range expectedMerges {
+		if got, ok := cfg.Merge[k]; !ok || got != v {
+			t.Errorf("expected merge strategy %q for %q, got %q", v, k, got)
+		}
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -114,6 +114,10 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 	}
 }
 
+// TestDefaultConfig verifies DefaultConfig wires the given Claude and seal
+// dirs, sets a non-empty DeviceID and the current ConfigVersion, applies the
+// expected auto-seal/unseal defaults (push/pull off), and ships the full set
+// of include, exclude, and per-path merge-strategy defaults.
 func TestDefaultConfig(t *testing.T) {
 	claudeDir := "/mock/claude"
 	sealDir := "/mock/seal"


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for the `DefaultConfig` function in `internal/config/config.go`.

📊 **Coverage:** The new test covers:
- Verification of default configuration values (e.g. `Version`, `DeviceID`).
- Verification that parameters `claudeDir` and `sealDir` are properly assigned.
- Verification of default boolean values in the `Sync` section.
- Verification of the correct population of default patterns in the `Include`, `Exclude` and `Merge` sections.

✨ **Result:** Test coverage for the `internal/config` package is significantly improved, ensuring `DefaultConfig` reliably generates the expected initial configuration and protecting against future regressions.

---
*PR created automatically by Jules for task [12008947432985869192](https://jules.google.com/task/12008947432985869192) started by @coredipper*