### PR TITLE
🧹 Refactor Long Function: Unseal

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -322,6 +322,42 @@ func isSessionPath(relPath string) bool {
 	return strings.HasPrefix(relPath, "projects/") && strings.HasSuffix(relPath, ".jsonl")
 }
 
+// unsealFile decrypts a single file and writes it to the claude directory.
+func unsealFile(store *ObjectStore, identity age.Identity, entry FileEntry, absPath, relPath string, verbose bool) (int, error) {
+	// Read encrypted object
+	encrypted, err := store.Read(entry.ContentHash)
+	if err != nil {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "  warning: missing object for %s: %v\n", relPath, err)
+		}
+		return 0, err
+	}
+
+	// Decrypt
+	plaintext, err := crypto.Decrypt(encrypted, identity)
+	if err != nil {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "  warning: cannot decrypt %s: %v\n", relPath, err)
+		}
+		return 0, err
+	}
+
+	// Write to claude directory
+	dir := filepath.Dir(absPath)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return 0, err
+	}
+	if err := os.WriteFile(absPath, plaintext, 0600); err != nil {
+		return 0, err
+	}
+	if entry.ModTimeNs != 0 {
+		mtime := time.Unix(0, entry.ModTimeNs)
+		os.Chtimes(absPath, mtime, mtime)
+	}
+
+	return len(plaintext), nil
+}
+
 // Unseal decrypts seal contents back to claudeDir and removes managed
 // files not in the manifest. The manifest is the source of truth.
 func Unseal(cfg *config.Config, identity age.Identity, verbose bool, progress ProgressFunc) (stats UnsealStats, err error) {
@@ -365,46 +401,17 @@ func Unseal(cfg *config.Config, identity age.Identity, verbose bool, progress Pr
 			}
 		}
 
-		// Read encrypted object
-		encrypted, err := store.Read(entry.ContentHash)
+		bytesDecrypted, err := unsealFile(store, identity, entry, absPath, relPath, verbose)
 		if err != nil {
-			if verbose {
-				fmt.Fprintf(os.Stderr, "  warning: missing object for %s: %v\n", relPath, err)
-			}
 			stats.Errors++
 			continue
-		}
-
-		// Decrypt
-		plaintext, err := crypto.Decrypt(encrypted, identity)
-		if err != nil {
-			if verbose {
-				fmt.Fprintf(os.Stderr, "  warning: cannot decrypt %s: %v\n", relPath, err)
-			}
-			stats.Errors++
-			continue
-		}
-
-		// Write to claude directory
-		dir := filepath.Dir(absPath)
-		if err := os.MkdirAll(dir, 0700); err != nil {
-			stats.Errors++
-			continue
-		}
-		if err := os.WriteFile(absPath, plaintext, 0600); err != nil {
-			stats.Errors++
-			continue
-		}
-		if entry.ModTimeNs != 0 {
-			mtime := time.Unix(0, entry.ModTimeNs)
-			os.Chtimes(absPath, mtime, mtime)
 		}
 
 		if verbose {
 			fmt.Printf("  [restore] %s (%s)\n", relPath, FormatSize(entry.SizePlaintext))
 		}
 		stats.Restored++
-		stats.BytesDecrypted += int64(len(plaintext))
+		stats.BytesDecrypted += int64(bytesDecrypted)
 	}
 
 	// Delete managed files not in the manifest. The manifest is the source


### PR DESCRIPTION
🎯 **What:** Extracted the logic for reading encrypted objects, decrypting their contents, and writing them back to disk from the main loop in the `Unseal` function to a new, separate helper function called `unsealFile`. 

💡 **Why:** The original `Unseal` function was long and mixed high-level manifest parsing logic with low-level file decryption and writing logic. By isolating the file-processing logic into `unsealFile`, the core `Unseal` function becomes shorter, more readable, and its intent is much clearer.

✅ **Verification:** 
- The refactored code has identical error handling and verbosity logging.
- `stats.BytesDecrypted` accurately increments based on returned values.
- Compiled the code manually to verify no errors.
- Ran all existing unit tests in `internal/store` ensuring no regressions.
- Passed `go fmt` and `go vet` checks.
- Completed thorough code review with no functional or styling issues found.

✨ **Result:** Improved maintainability, cleaner codebase, and reduced cognitive load when analyzing the file decryption workflow. No functionality was changed.

---
*PR created automatically by Jules for task [10317471276579797546](https://jules.google.com/task/10317471276579797546) started by @coredipper*