### PR TITLE
🧹 Refactor: Extract helper functions from Seal

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -182,86 +182,103 @@ func Seal(cfg *config.Config, recipient age.Recipient, verbose bool, progress Pr
 		}
 		seen[f.RelPath] = true
 
-		// Fast path optimization for Seal
-		if entry, ok := manifest.Files[f.RelPath]; ok && entry.ModTimeNs != 0 {
-			if entry.SizePlaintext == f.Size && entry.ModTimeNs == f.ModTimeNs {
-				if store.Exists(entry.ContentHash) {
-					stats.Unchanged++
-					continue
-				}
+		processFile(f, manifest, store, recipient, cfg, activeSessions, verbose, &stats)
+	}
+
+	trackDeleted(manifest, seen, verbose, &stats)
+	tallySessions(manifest, prior, &stats)
+
+	// Save manifest
+	if err := manifest.Save(sealDir); err != nil {
+		return stats, fmt.Errorf("saving manifest: %w", err)
+	}
+
+	stats.Elapsed = time.Since(start)
+	return stats, nil
+}
+
+func processFile(f ScanResult, manifest *Manifest, store *ObjectStore, recipient age.Recipient, cfg *config.Config, activeSessions map[string]bool, verbose bool, stats *SealStats) {
+	// Fast path optimization for Seal
+	if entry, ok := manifest.Files[f.RelPath]; ok && entry.ModTimeNs != 0 {
+		if entry.SizePlaintext == f.Size && entry.ModTimeNs == f.ModTimeNs {
+			if store.Exists(entry.ContentHash) {
+				stats.Unchanged++
+				return
 			}
-		}
-
-		plaintext, err := os.ReadFile(f.AbsPath)
-		if err != nil {
-			if verbose {
-				fmt.Fprintf(os.Stderr, "  warning: cannot read %s: %v\n", f.RelPath, err)
-			}
-			stats.Errors++
-			continue
-		}
-
-		hash := ContentHash(plaintext)
-
-		// Check if unchanged
-		if existing, ok := manifest.Files[f.RelPath]; ok && existing.ContentHash == hash && store.Exists(hash) {
-			stats.Unchanged++
-			continue
-		}
-
-		// Encrypt and store
-		encrypted, err := crypto.Encrypt(plaintext, recipient)
-		if err != nil {
-			if verbose {
-				fmt.Fprintf(os.Stderr, "  warning: cannot encrypt %s: %v\n", f.RelPath, err)
-			}
-			stats.Errors++
-			continue
-		}
-
-		if err := store.Write(hash, encrypted); err != nil {
-			stats.Errors++
-			continue
-		}
-
-		// Determine if this is new or modified
-		if _, existed := manifest.Files[f.RelPath]; existed {
-			stats.Modified++
-		} else {
-			stats.Added++
-		}
-		stats.BytesPlaintext += f.Size
-		stats.BytesEncrypted += int64(len(encrypted))
-
-		if verbose {
-			action := "new"
-			if _, existed := manifest.Files[f.RelPath]; existed {
-				action = "mod"
-			}
-			fmt.Printf("  [%s] %s (%s)\n", action, f.RelPath, FormatSize(f.Size))
-		}
-
-		// Count JSONL lines if applicable
-		lineCount := 0
-		if strings.HasSuffix(f.RelPath, ".jsonl") {
-			lineCount = bytes.Count(plaintext, []byte("\n"))
-			if len(plaintext) > 0 && plaintext[len(plaintext)-1] != '\n' {
-				lineCount++ // last line without trailing newline
-			}
-		}
-
-		manifest.Files[f.RelPath] = FileEntry{
-			ContentHash:     hash,
-			SizePlaintext:   f.Size,
-			SizeEncrypted:   int64(len(encrypted)),
-			Mtime:           time.Unix(0, f.ModTimeNs).UTC().Format(time.RFC3339),
-			ModTimeNs:       f.ModTimeNs,
-			MergeStrategy:   ResolveMergeStrategy(f.RelPath, cfg.Merge),
-			JSONLLineCount:  lineCount,
-			SessionComplete: isSessionCompleteFor(f.RelPath, activeSessions),
 		}
 	}
 
+	plaintext, err := os.ReadFile(f.AbsPath)
+	if err != nil {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "  warning: cannot read %s: %v\n", f.RelPath, err)
+		}
+		stats.Errors++
+		return
+	}
+
+	hash := ContentHash(plaintext)
+
+	// Check if unchanged
+	if existing, ok := manifest.Files[f.RelPath]; ok && existing.ContentHash == hash && store.Exists(hash) {
+		stats.Unchanged++
+		return
+	}
+
+	// Encrypt and store
+	encrypted, err := crypto.Encrypt(plaintext, recipient)
+	if err != nil {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "  warning: cannot encrypt %s: %v\n", f.RelPath, err)
+		}
+		stats.Errors++
+		return
+	}
+
+	if err := store.Write(hash, encrypted); err != nil {
+		stats.Errors++
+		return
+	}
+
+	// Determine if this is new or modified
+	if _, existed := manifest.Files[f.RelPath]; existed {
+		stats.Modified++
+	} else {
+		stats.Added++
+	}
+	stats.BytesPlaintext += f.Size
+	stats.BytesEncrypted += int64(len(encrypted))
+
+	if verbose {
+		action := "new"
+		if _, existed := manifest.Files[f.RelPath]; existed {
+			action = "mod"
+		}
+		fmt.Printf("  [%s] %s (%s)\n", action, f.RelPath, FormatSize(f.Size))
+	}
+
+	// Count JSONL lines if applicable
+	lineCount := 0
+	if strings.HasSuffix(f.RelPath, ".jsonl") {
+		lineCount = bytes.Count(plaintext, []byte("\n"))
+		if len(plaintext) > 0 && plaintext[len(plaintext)-1] != '\n' {
+			lineCount++ // last line without trailing newline
+		}
+	}
+
+	manifest.Files[f.RelPath] = FileEntry{
+		ContentHash:     hash,
+		SizePlaintext:   f.Size,
+		SizeEncrypted:   int64(len(encrypted)),
+		Mtime:           time.Unix(0, f.ModTimeNs).UTC().Format(time.RFC3339),
+		ModTimeNs:       f.ModTimeNs,
+		MergeStrategy:   ResolveMergeStrategy(f.RelPath, cfg.Merge),
+		JSONLLineCount:  lineCount,
+		SessionComplete: isSessionCompleteFor(f.RelPath, activeSessions),
+	}
+}
+
+func trackDeleted(manifest *Manifest, seen map[string]bool, verbose bool, stats *SealStats) {
 	// Mark deleted files
 	for path := range manifest.Files {
 		if !seen[path] {
@@ -272,7 +289,9 @@ func Seal(cfg *config.Config, recipient age.Recipient, verbose bool, progress Pr
 			stats.Deleted++
 		}
 	}
+}
 
+func tallySessions(manifest *Manifest, prior map[string]FileEntry, stats *SealStats) {
 	// Tally session activity against the prior manifest. "Updated" counts
 	// session JSONLs whose JSONLLineCount grew since the previous seal —
 	// the most reliable signal short of consulting live process state.
@@ -290,14 +309,6 @@ func Seal(cfg *config.Config, recipient age.Recipient, verbose bool, progress Pr
 			stats.Sessions.Updated++
 		}
 	}
-
-	// Save manifest
-	if err := manifest.Save(sealDir); err != nil {
-		return stats, fmt.Errorf("saving manifest: %w", err)
-	}
-
-	stats.Elapsed = time.Since(start)
-	return stats, nil
 }
 
 // activeSessionIDs returns the set of session UUIDs currently associated


### PR DESCRIPTION
🎯 **What:** Extracted the core loop logic, deleted file tracking, and session tallying from the `Seal` function into three self-contained, private helper functions: `processFile`, `trackDeleted`, and `tallySessions`.

💡 **Why:** The original `Seal` function was exceptionally long (~160 lines) and carried out several distinct responsibilities. Breaking it down into helper functions isolates the complex per-file processing logic and improves overall function readability, making future maintenance easier.

✅ **Verification:**
- Validated via `go fmt ./...` and `go vet ./...`.
- Verified that all tests pass (`go test ./...`) with no regressions.
- Code review approved the extraction, confirming that logic flows exactly the same and no edge cases or state tracking were dropped.

✨ **Result:** The `Seal` function is now much shorter, serving purely as an orchestrator, while the distinct file/session steps are clearly encapsulated in logically named private functions.

---
*PR created automatically by Jules for task [10327644375126441749](https://jules.google.com/task/10327644375126441749) started by @coredipper*