### PR TITLE
fix(seal): reuse existing objects instead of re-encrypting identical content

### DIFF
--- a/internal/store/objects.go
+++ b/internal/store/objects.go
@@ -36,6 +36,17 @@ func (s *ObjectStore) Exists(hash string) bool {
 	return err == nil
 }
 
+// Size returns the on-disk size of the object for the given hash, and whether
+// it exists — one stat for callers that reuse an existing object and need its
+// encrypted size without reading it.
+func (s *ObjectStore) Size(hash string) (int64, bool) {
+	info, err := os.Stat(s.ObjectPath(hash))
+	if err != nil {
+		return 0, false
+	}
+	return info.Size(), true
+}
+
 // Write stores encrypted data at the content-addressed path.
 func (s *ObjectStore) Write(hash string, encrypted []byte) error {
 	path := s.ObjectPath(hash)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -226,19 +226,29 @@ func processFile(f ScanResult, manifest *Manifest, store *ObjectStore, recipient
 		return
 	}
 
-	// Encrypt and store
-	encrypted, err := crypto.Encrypt(plaintext, recipient)
-	if err != nil {
-		if verbose {
-			fmt.Fprintf(os.Stderr, "  warning: cannot encrypt %s: %v\n", f.RelPath, err)
+	// Encrypt and store — unless the content already has an object under
+	// another key (the same file synced from a machine with different project
+	// keys, or duplicate content). age output is non-deterministic, so
+	// re-encrypting identical plaintext would rewrite blob bytes git has
+	// already committed and re-push the whole object. Rotate overwrites
+	// ciphertext in place on purpose, so this check stays out of
+	// ObjectStore.Write.
+	encSize, exists := store.Size(hash)
+	if !exists {
+		encrypted, err := crypto.Encrypt(plaintext, recipient)
+		if err != nil {
+			if verbose {
+				fmt.Fprintf(os.Stderr, "  warning: cannot encrypt %s: %v\n", f.RelPath, err)
+			}
+			stats.Errors++
+			return
 		}
-		stats.Errors++
-		return
-	}
 
-	if err := store.Write(hash, encrypted); err != nil {
-		stats.Errors++
-		return
+		if err := store.Write(hash, encrypted); err != nil {
+			stats.Errors++
+			return
+		}
+		encSize = int64(len(encrypted))
 	}
 
 	// Determine if this is new or modified
@@ -248,7 +258,7 @@ func processFile(f ScanResult, manifest *Manifest, store *ObjectStore, recipient
 		stats.Added++
 	}
 	stats.BytesPlaintext += f.Size
-	stats.BytesEncrypted += int64(len(encrypted))
+	stats.BytesEncrypted += encSize
 
 	if verbose {
 		action := "new"
@@ -270,7 +280,7 @@ func processFile(f ScanResult, manifest *Manifest, store *ObjectStore, recipient
 	manifest.Files[f.RelPath] = FileEntry{
 		ContentHash:     hash,
 		SizePlaintext:   f.Size,
-		SizeEncrypted:   int64(len(encrypted)),
+		SizeEncrypted:   encSize,
 		Mtime:           time.Unix(0, f.ModTimeNs).UTC().Format(time.RFC3339),
 		ModTimeNs:       f.ModTimeNs,
 		MergeStrategy:   ResolveMergeStrategy(f.RelPath, cfg.Merge),

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -561,4 +562,69 @@ func TestUnseal_ObjectsButNoManifest(t *testing.T) {
 			t.Errorf("error %q is missing the initialized hint", err.Error())
 		}
 	})
+}
+
+// TestSeal_ReusesExistingObjectForNewPath guards the write side of the
+// content-addressed dedup: sealing a new path whose content is already in the
+// object store must not rewrite the blob. age encryption is non-deterministic,
+// so re-encrypting identical plaintext changes bytes git has already
+// committed, re-committing full copies of data that did not change.
+func TestSeal_ReusesExistingObjectForNewPath(t *testing.T) {
+	claudeDir := t.TempDir()
+	content := []byte("# identical content\n")
+	if err := os.WriteFile(filepath.Join(claudeDir, "CLAUDE.md"), content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sealDir := t.TempDir()
+	identity, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey() error: %v", err)
+	}
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+
+	if _, err := Seal(cfg, identity.Recipient(), false, nil); err != nil {
+		t.Fatalf("first Seal() error: %v", err)
+	}
+	hash := ContentHash(content)
+	store := NewObjectStore(sealDir)
+	before, err := store.Read(hash)
+	if err != nil {
+		t.Fatalf("object missing after first seal: %v", err)
+	}
+
+	// Same content appears under a second managed path.
+	if err := os.WriteFile(filepath.Join(claudeDir, "RTK.md"), content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	stats, err := Seal(cfg, identity.Recipient(), false, nil)
+	if err != nil {
+		t.Fatalf("second Seal() error: %v", err)
+	}
+	if stats.Added != 1 {
+		t.Errorf("Added = %d, want 1", stats.Added)
+	}
+
+	after, err := store.Read(hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Error("object rewritten: same plaintext re-encrypted to different ciphertext")
+	}
+
+	m, err := LoadManifest(sealDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := m.Files["RTK.md"]
+	if !ok {
+		t.Fatal("RTK.md missing from manifest")
+	}
+	if entry.ContentHash != hash {
+		t.Errorf("RTK.md ContentHash = %s, want %s", entry.ContentHash, hash)
+	}
+	if entry.SizeEncrypted != int64(len(before)) {
+		t.Errorf("SizeEncrypted = %d, want %d (existing object's size)", entry.SizeEncrypted, len(before))
+	}
 }

--- a/internal/store/unseal_remap_test.go
+++ b/internal/store/unseal_remap_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -172,5 +173,66 @@ func TestUnsealStatus_RemapOff(t *testing.T) {
 	}
 	if !sawForeign {
 		t.Errorf("RemapOff dry-run should preview the verbatim foreign key %q; got %v", foreignRel, diff.Added)
+	}
+}
+
+// TestUnsealThenSeal_PreservesObjectBytesAcrossDeviceSwitch guards against
+// history bloat on machine switches: the first seal after a remapped unseal
+// re-keys the manifest to local project keys, and every object blob must
+// survive byte-identical — only the keys changed, not the content, and a
+// rewrite would re-commit the full store to the synced git history on every
+// switch.
+func TestUnsealThenSeal_PreservesObjectBytesAcrossDeviceSwitch(t *testing.T) {
+	sealDir, id, foreignRel := sealForeignProject(t)
+
+	objStore := NewObjectStore(sealDir)
+	hashes, err := objStore.ListAll()
+	if err != nil || len(hashes) == 0 {
+		t.Fatalf("want sealed objects, got %d (err=%v)", len(hashes), err)
+	}
+	before := make(map[string][]byte, len(hashes))
+	for _, h := range hashes {
+		b, err := objStore.Read(h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		before[h] = b
+	}
+
+	dstHome := t.TempDir()
+	dstClaude := filepath.Join(dstHome, ".claude")
+	cfg := config.DefaultConfig(dstClaude, sealDir)
+	if _, err := Unseal(cfg, id, false, nil, WithRemap(RemapAuto)); err != nil {
+		t.Fatalf("Unseal: %v", err)
+	}
+
+	if _, err := Seal(cfg, id.Recipient(), false, nil); err != nil {
+		t.Fatalf("re-seal: %v", err)
+	}
+
+	for h, b := range before {
+		after, err := objStore.Read(h)
+		if err != nil {
+			t.Fatalf("object %s missing after re-seal: %v", h[:16], err)
+		}
+		if !bytes.Equal(b, after) {
+			t.Errorf("object %s rewritten by re-seal", h[:16])
+		}
+	}
+
+	m, err := LoadManifest(sealDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	localKey := "projects/" + encodePath(dstHome) + "-core-enclaude/a.jsonl"
+	entry, ok := m.Files[localKey]
+	if !ok {
+		t.Fatalf("manifest missing local key %s", localKey)
+	}
+	if !objStore.Exists(entry.ContentHash) {
+		t.Errorf("local entry points at missing object %s", entry.ContentHash[:16])
+	}
+	if _, ok := m.Files[foreignRel]; ok {
+		t.Errorf("foreign key %s still in manifest after re-seal", foreignRel)
 	}
 }


### PR DESCRIPTION
## Problem

Follow-up to #95. The cross-device remap restores projects under *local* keys, but the seal store's manifest keeps the originating machine's keys until the next seal re-keys it. That seal pays a hidden cost: `processFile` only skips encryption when the **same relPath** already maps to the hash, so every re-keyed file (and any duplicate content at a second path) is re-encrypted. age output is non-deterministic — identical plaintext produces different ciphertext — and `ObjectStore.Write` overwrites unconditionally, so every blob in the store gets rewritten byte-for-byte different under the same filename. Encrypted blobs don't delta-compress, so the synced git history grows by roughly the full store size on **every machine switch** (~270 MB per laptop↔desktop alternation for the store in #94).

## Fix

- **`internal/store/objects.go`** — new `ObjectStore.Size(hash) (int64, bool)`: one stat that doubles as the existence check and provides the encrypted size without reading the blob.
- **`internal/store/store.go`** — `processFile` consults `store.Size(hash)` before encrypting: if the object already exists, the manifest entry simply points at it (`SizeEncrypted` from the stat) and no bytes change on disk. The check deliberately lives in `processFile`, **not** in `ObjectStore.Write` — `Rotate` overwrites ciphertext in place on purpose and must keep doing so. `Repair`'s missing/corrupt re-encryption path calls `Write` directly and is likewise untouched.

## Tests

Both written first and failing on `main` with "object rewritten":

- `TestSeal_ReusesExistingObjectForNewPath` — second path with already-stored content: blob bytes unchanged, new manifest entry points at the existing hash with the stat-derived `SizeEncrypted`.
- `TestUnsealThenSeal_PreservesObjectBytesAcrossDeviceSwitch` — the #95 scenario end-to-end: seal under a foreign home, remap-unseal on a second machine, re-seal — every object byte-identical, manifest re-keyed to local, foreign key gone.

`go test ./... -count=1` green · `gofmt -l` clean · `go vet` clean · `make build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)