### PR TITLE
fix: harden the seal-store flows around the cross-device fixes

### DIFF
--- a/cmd/hook_handler.go
+++ b/cmd/hook_handler.go
@@ -152,22 +152,18 @@ func handleSessionEnd() error {
 		return nil
 	}
 
-	// Commit if changes
-	if stats.HasChanges() {
-		git := gitops.New(sealDir)
-		if err := git.AddAll(); err != nil {
-			logHook("git add warning: %v", err)
-			return nil
-		}
-		msg := fmt.Sprintf("seal: auto-seal from %s (%s)",
-			cfg.Seal.DeviceID, stats)
-		if err := git.Commit(msg); err != nil {
-			logHook("git commit warning: %v", err)
-			return nil
-		}
+	msg := fmt.Sprintf("seal: auto-seal from %s (%s)",
+		cfg.Seal.DeviceID, stats)
+	committed, err := commitSealStore(sealDir, msg)
+	if err != nil {
+		logHook("git warning: %v", err)
+		return nil
+	}
 
-		// Push if auto-push enabled
-		if cfg.Sync.AutoPush && git.HasRemote("origin") {
+	// Push if auto-push enabled
+	if committed && cfg.Sync.AutoPush {
+		git := gitops.New(sealDir)
+		if git.HasRemote("origin") {
 			branch, _ := git.CurrentBranch()
 			if _, out, err := git.Push("origin", branch); err != nil {
 				logHook("push warning: %v (%s)", err, out)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -57,15 +57,10 @@ func runPush(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Println(stats.Multiline("  "))
 
-	if stats.HasChanges() {
-		if err := git.AddAll(); err != nil {
-			return fmt.Errorf("git add: %w", err)
-		}
-		msg := fmt.Sprintf("seal: seal from %s (%s)",
-			cfg.Seal.DeviceID, stats)
-		if err := git.Commit(msg); err != nil {
-			return fmt.Errorf("git commit: %w", err)
-		}
+	msg := fmt.Sprintf("seal: seal from %s (%s)",
+		cfg.Seal.DeviceID, stats)
+	if _, err := commitSealStore(sealDir, msg); err != nil {
+		return err
 	}
 
 	// Push

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/coredipper/enclaude/internal/crypto"
+	"github.com/coredipper/enclaude/internal/gitops"
 	"github.com/coredipper/enclaude/internal/store"
 	"github.com/coredipper/enclaude/internal/ui"
 	"github.com/spf13/cobra"
@@ -73,4 +74,23 @@ func getSealDir() string {
 		os.Exit(1)
 	}
 	return home + "/.enclaude"
+}
+
+// commitSealStore stages the seal dir and commits when anything is staged,
+// returning whether a commit was made. The commit is gated on staged changes
+// rather than the seal's own stats: AddAll force-stages store metadata that a
+// gitignore may have kept out of history, and that rescue must not wait for
+// the next content change.
+func commitSealStore(sealDir, msg string) (bool, error) {
+	git := gitops.New(sealDir)
+	if err := git.AddAll(); err != nil {
+		return false, fmt.Errorf("git add: %w", err)
+	}
+	if !git.HasCachedChanges() {
+		return false, nil
+	}
+	if err := git.Commit(msg); err != nil {
+		return false, fmt.Errorf("git commit: %w", err)
+	}
+	return true, nil
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/coredipper/enclaude/internal/gitops"
+)
+
+// TestCommitSealStore_RescuesIgnoredMetadataWithoutContentChanges guards the
+// heal path: a store whose manifest.json was kept out of history by a global
+// gitignore must get committed by the next seal/sync/push even when the seal
+// itself saw no content changes — gating the commit on seal stats leaves the
+// clone-breaking gap open until the next unrelated edit.
+func TestCommitSealStore_RescuesIgnoredMetadataWithoutContentChanges(t *testing.T) {
+	for _, k := range []string{"GIT_AUTHOR_NAME", "GIT_COMMITTER_NAME"} {
+		t.Setenv(k, "Test User")
+	}
+	for _, k := range []string{"GIT_AUTHOR_EMAIL", "GIT_COMMITTER_EMAIL"} {
+		t.Setenv(k, "test@example.com")
+	}
+
+	dir := t.TempDir()
+	g := gitops.New(dir)
+	if err := g.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "seal.toml"), []byte("config_version = 2\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	committed, err := commitSealStore(dir, "initial")
+	if err != nil {
+		t.Fatalf("commitSealStore(initial): %v", err)
+	}
+	if !committed {
+		t.Fatal("initial commitSealStore reported nothing to commit")
+	}
+
+	// A hostile global rule (same precedence as core.excludesFile) kept
+	// manifest.json untracked; no other changes exist.
+	exclude := filepath.Join(dir, ".git", "info", "exclude")
+	if err := os.WriteFile(exclude, []byte("manifest.json\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	committed, err = commitSealStore(dir, "heal")
+	if err != nil {
+		t.Fatalf("commitSealStore(heal): %v", err)
+	}
+	if !committed {
+		t.Error("commitSealStore did not commit the rescued manifest.json")
+	}
+	if _, err := g.ShowFileAtRef("HEAD", "manifest.json"); err != nil {
+		t.Errorf("manifest.json not in HEAD after heal commit: %v", err)
+	}
+
+	committed, err = commitSealStore(dir, "noop")
+	if err != nil {
+		t.Fatalf("commitSealStore(noop): %v", err)
+	}
+	if committed {
+		t.Error("commitSealStore committed with nothing staged")
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,8 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/coredipper/enclaude/internal/config"
+	"github.com/coredipper/enclaude/internal/crypto"
 	"github.com/coredipper/enclaude/internal/gitops"
+	"github.com/coredipper/enclaude/internal/store"
 )
 
 // TestCommitSealStore_RescuesIgnoredMetadataWithoutContentChanges guards the
@@ -64,5 +68,59 @@ func TestCommitSealStore_RescuesIgnoredMetadataWithoutContentChanges(t *testing.
 	}
 	if committed {
 		t.Error("commitSealStore committed with nothing staged")
+	}
+}
+
+// TestCommitSealStore_NoOpSealCreatesNoCommit exercises the seal→commit flow
+// end to end on an unchanged store: the second seal must produce nothing to
+// commit. Guards the staged-diff gate against manifest timestamp churn —
+// without it every session-end hook run would add a commit.
+func TestCommitSealStore_NoOpSealCreatesNoCommit(t *testing.T) {
+	for _, k := range []string{"GIT_AUTHOR_NAME", "GIT_COMMITTER_NAME"} {
+		t.Setenv(k, "Test User")
+	}
+	for _, k := range []string{"GIT_AUTHOR_EMAIL", "GIT_COMMITTER_EMAIL"} {
+		t.Setenv(k, "test@example.com")
+	}
+
+	claudeDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(claudeDir, "CLAUDE.md"), []byte("# hi\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	sealDir := t.TempDir()
+	if err := gitops.New(sealDir).Init(); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey() error: %v", err)
+	}
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+
+	if _, err := store.Seal(cfg, identity.Recipient(), false, nil); err != nil {
+		t.Fatalf("first Seal() error: %v", err)
+	}
+	committed, err := commitSealStore(sealDir, "initial seal")
+	if err != nil {
+		t.Fatalf("commitSealStore(initial): %v", err)
+	}
+	if !committed {
+		t.Fatal("initial seal produced nothing to commit")
+	}
+
+	// sealed_at has second resolution: without crossing a boundary, a
+	// rewritten manifest is byte-identical and git can't see the churn this
+	// test exists to catch.
+	time.Sleep(1100 * time.Millisecond)
+
+	if _, err := store.Seal(cfg, identity.Recipient(), false, nil); err != nil {
+		t.Fatalf("second Seal() error: %v", err)
+	}
+	committed, err = commitSealStore(sealDir, "no-op seal")
+	if err != nil {
+		t.Fatalf("commitSealStore(no-op): %v", err)
+	}
+	if committed {
+		t.Error("no-op seal created a commit (manifest timestamp churn)")
 	}
 }

--- a/cmd/seal.go
+++ b/cmd/seal.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/coredipper/enclaude/internal/config"
 	"github.com/coredipper/enclaude/internal/crypto"
-	"github.com/coredipper/enclaude/internal/gitops"
 	"github.com/coredipper/enclaude/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -73,18 +72,13 @@ func runSeal(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("seal had %d errors", stats.Errors)
 	}
 
-	// Commit if there are changes
-	if stats.HasChanges() {
-		git := gitops.New(sealDir)
-		if err := git.AddAll(); err != nil {
-			return fmt.Errorf("git add: %w", err)
-		}
-
-		msg := fmt.Sprintf("seal: seal from %s (%s)",
-			cfg.Seal.DeviceID, stats)
-		if err := git.Commit(msg); err != nil {
-			return fmt.Errorf("git commit: %w", err)
-		}
+	msg := fmt.Sprintf("seal: seal from %s (%s)",
+		cfg.Seal.DeviceID, stats)
+	committed, err := commitSealStore(sealDir, msg)
+	if err != nil {
+		return err
+	}
+	if committed {
 		fmt.Println("  Committed to seal store.")
 	} else {
 		fmt.Println("  No changes to commit.")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -62,15 +62,10 @@ func runSync(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Println(sealStats.Multiline("    "))
 
-	if sealStats.HasChanges() {
-		if err := git.AddAll(); err != nil {
-			return fmt.Errorf("git add: %w", err)
-		}
-		msg := fmt.Sprintf("seal: seal from %s (%s)",
-			cfg.Seal.DeviceID, sealStats)
-		if err := git.Commit(msg); err != nil {
-			return fmt.Errorf("git commit: %w", err)
-		}
+	msg := fmt.Sprintf("seal: seal from %s (%s)",
+		cfg.Seal.DeviceID, sealStats)
+	if _, err := commitSealStore(sealDir, msg); err != nil {
+		return err
 	}
 
 	// 2. Pull

--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -91,15 +91,16 @@ func (g *Git) Add(paths ...string) error {
 }
 
 // AddAll stages all changes, then force-stages the seal store payload —
-// manifest.json and the objects/ blobs. A user's global gitignore
+// manifest.json, the objects/ blobs, and seal.toml. A user's global gitignore
 // (core.excludesFile) can otherwise silently drop files an unseal needs:
-// without the manifest there is no relPath->hash mapping, and without the
-// objects the manifest's hashes point at blobs that were never committed.
+// without the manifest there is no relPath->hash mapping, without the objects
+// the manifest's hashes point at blobs that were never committed, and without
+// the config a clone fails before it even looks for the manifest.
 func (g *Git) AddAll() error {
 	if _, err := g.run("add", "."); err != nil {
 		return err
 	}
-	for _, p := range []string{"manifest.json", "objects"} {
+	for _, p := range []string{"manifest.json", "objects", "seal.toml"} {
 		if _, err := os.Stat(filepath.Join(g.dir, p)); err != nil {
 			continue
 		}

--- a/internal/gitops/git_test.go
+++ b/internal/gitops/git_test.go
@@ -814,3 +814,44 @@ func TestAddAll_ForceStagesIgnoredObjects(t *testing.T) {
 		t.Errorf("object blob was not staged despite ignore rule; git ls-files = %q", out)
 	}
 }
+
+// TestAddAll_ForceStagesIgnoredSealToml guards that AddAll stages seal.toml
+// even when a gitignore rule (e.g. a global *.toml) would exclude it. Without
+// the config a clone fails at config.Load before unseal can even look for the
+// manifest.
+func TestAddAll_ForceStagesIgnoredSealToml(t *testing.T) {
+	dir := t.TempDir()
+	g := New(dir)
+	if err := g.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := g.run("config", "user.name", "Test User"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := g.run("config", "user.email", "test@example.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stand in for a hostile global core.excludesFile without touching the
+	// user's real git config: .git/info/exclude has the same precedence.
+	exclude := filepath.Join(dir, ".git", "info", "exclude")
+	if err := os.WriteFile(exclude, []byte("*.toml\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "seal.toml"), []byte("config_version = 2\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := g.AddAll(); err != nil {
+		t.Fatalf("AddAll() error: %v", err)
+	}
+
+	out, err := g.run("ls-files")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "seal.toml") {
+		t.Errorf("seal.toml was not staged despite ignore rule; git ls-files = %q", out)
+	}
+}

--- a/internal/store/remap.go
+++ b/internal/store/remap.go
@@ -53,6 +53,9 @@ type RemapPlan struct {
 	SrcKey   string // encoded project segment, e.g. "-home-daniel-core-enclaude"
 	DstKey   string // local segment, e.g. "-Users-bob-core-enclaude"
 	Accepted bool
+	// Pinned marks a plan resolved by a device-local override. Pins are
+	// settled decisions, so interactive unseals apply them without re-asking.
+	Pinned bool
 }
 
 // homeDir returns the local machine's home directory: the parent of ~/.claude
@@ -157,7 +160,7 @@ func PlanRemap(m *Manifest, dstHomeEnc, originHomeEnc string, overrides map[stri
 		seen[seg] = true
 
 		if dst, ok := overrides[seg]; ok {
-			plans = append(plans, RemapPlan{SrcKey: seg, DstKey: dst, Accepted: true})
+			plans = append(plans, RemapPlan{SrcKey: seg, DstKey: dst, Accepted: true, Pinned: true})
 			continue
 		}
 
@@ -270,8 +273,9 @@ func candidateBetter(a, b remapCandidate) bool {
 
 // remapManifest rewrites foreign project keys in m into an effective local
 // manifest per mode. Returns m unchanged for RemapOff or when nothing foreign
-// is found. In RemapInteractive it consults DefaultRemapResolver and persists
-// the resulting decisions as device-local overrides so later unseals are silent.
+// is found. In RemapInteractive it consults DefaultRemapResolver for the plans
+// not already settled by a pin, then persists every decision — including
+// declines — as device-local overrides so later unseals are silent.
 func remapManifest(m *Manifest, cfg *config.Config, mode RemapMode) (*Manifest, error) {
 	if mode == RemapOff {
 		return m, nil
@@ -286,25 +290,41 @@ func remapManifest(m *Manifest, cfg *config.Config, mode RemapMode) (*Manifest, 
 		return m, nil
 	}
 	if mode == RemapInteractive && DefaultRemapResolver != nil {
-		resolved, err := DefaultRemapResolver(plans)
-		if err != nil {
-			return m, err
+		var ask, settled []RemapPlan
+		for _, p := range plans {
+			if p.Pinned {
+				settled = append(settled, p)
+			} else {
+				ask = append(ask, p)
+			}
 		}
-		plans = resolved
-		persistOverrides(cfg.Seal.SealDir, plans)
+		if len(ask) > 0 {
+			resolved, err := DefaultRemapResolver(ask)
+			if err != nil {
+				return m, err
+			}
+			persistOverrides(cfg.Seal.SealDir, resolved)
+			settled = append(settled, resolved...)
+		}
+		plans = settled
 	}
 	return ApplyRemap(m, plans), nil
 }
 
-// persistOverrides records the accepted plans as device-local overrides
+// persistOverrides records the resolver's decisions as device-local overrides
 // (best-effort: the remap is already applied, so a write failure only costs a
-// re-prompt next time).
+// re-prompt next time). A decline is a decision too — it pins the key to
+// itself so the next unseal doesn't re-ask.
 func persistOverrides(sealDir string, plans []RemapPlan) {
 	ov := LoadOverrides(sealDir)
 	changed := false
 	for _, p := range plans {
-		if p.Accepted && p.DstKey != "" && ov[p.SrcKey] != p.DstKey {
-			ov[p.SrcKey] = p.DstKey
+		target := p.DstKey
+		if !p.Accepted || target == "" {
+			target = p.SrcKey
+		}
+		if ov[p.SrcKey] != target {
+			ov[p.SrcKey] = target
 			changed = true
 		}
 	}
@@ -325,6 +345,10 @@ type ProjectInfo struct {
 // or foreign relative to this machine, attaching any device-local override.
 func ProjectDirs(m *Manifest, cfg *config.Config) []ProjectInfo {
 	dst := localHomeEnc(cfg)
+	var originEnc string
+	if m.OriginHome != "" {
+		originEnc = encodePath(m.OriginHome)
+	}
 	overrides := LoadOverrides(cfg.Seal.SealDir)
 	counts := map[string]int{}
 	for relPath := range m.Files {
@@ -334,15 +358,31 @@ func ProjectDirs(m *Manifest, cfg *config.Config) []ProjectInfo {
 	}
 	out := make([]ProjectInfo, 0, len(counts))
 	for seg, n := range counts {
-		prefix := encodedHomePrefix(seg)
 		out = append(out, ProjectInfo{
 			Key:      seg,
 			Files:    n,
-			Foreign:  prefix != "" && prefix != dst,
+			Foreign:  segIsForeign(seg, dst, originEnc),
 			Override: overrides[seg],
 		})
 	}
 	return out
+}
+
+// segIsForeign mirrors PlanRemap's source detection so `project list` agrees
+// with what unseal would remap: the authoritative origin home is consulted
+// first (it wins even when the local home is a boundary prefix of it, and it
+// recognizes homes the lossy heuristic can't), then already-local, then the
+// -Users/-home/-root prefix heuristic.
+func segIsForeign(seg, dstHomeEnc, originHomeEnc string) bool {
+	switch {
+	case originHomeEnc != "" && originHomeEnc != dstHomeEnc && hasEncodedPrefix(seg, originHomeEnc):
+		return true
+	case hasEncodedPrefix(seg, dstHomeEnc):
+		return false
+	default:
+		prefix := encodedHomePrefix(seg)
+		return prefix != "" && prefix != dstHomeEnc
+	}
 }
 
 // NormalizeProjectKey accepts either an absolute project path or an

--- a/internal/store/remap_test.go
+++ b/internal/store/remap_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/coredipper/enclaude/internal/config"
 )
 
 // TestEncodePath_DotAndSlash pins the project-key encoding that Claude Code
@@ -230,5 +232,28 @@ func TestLoadSaveOverrides_RoundTrip(t *testing.T) {
 	}
 	if _, err := filepath.Abs(filepath.Join(dir, "projectmap.local.toml")); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestProjectDirs_OriginHomeMarksUnrecognizedForeign verifies that `project
+// list` classification consults manifest.OriginHome like PlanRemap does: a
+// foreign home outside the -Users/-home/-root heuristic (e.g. /var/home/x)
+// must still show as foreign, since unseal would remap it via the
+// authoritative origin.
+func TestProjectDirs_OriginHomeMarksUnrecognizedForeign(t *testing.T) {
+	m := &Manifest{
+		OriginHome: "/var/home/x",
+		Files: map[string]FileEntry{
+			"projects/-var-home-x-proj/a.jsonl": {},
+		},
+	}
+	cfg := config.DefaultConfig("/Users/testbob/.claude", t.TempDir())
+
+	infos := ProjectDirs(m, cfg)
+	if len(infos) != 1 {
+		t.Fatalf("got %d project infos, want 1", len(infos))
+	}
+	if !infos[0].Foreign {
+		t.Errorf("key %s with OriginHome %s not classified foreign", infos[0].Key, m.OriginHome)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -174,6 +174,15 @@ func Seal(cfg *config.Config, recipient age.Recipient, verbose bool, progress Pr
 	}
 	stats.Scanned = len(files)
 
+	// A zero-file scan against a populated manifest is almost always a wrong
+	// claude_dir (a synced foreign path, a typo'd --claude-dir) — sealing it
+	// would track every entry as deleted, and a later unseal turns that into
+	// real deletions on other machines. Refuse rather than wipe.
+	if len(files) == 0 && len(manifest.Files) > 0 {
+		return stats, fmt.Errorf("scanned 0 files under %s but the manifest tracks %d — refusing to seal what would delete every entry; check claude_dir (or --claude-dir), or delete the seal store and re-init if this is intentional",
+			cfg.Seal.ClaudeDir, len(manifest.Files))
+	}
+
 	// Track which files still exist (for deletion detection)
 	seen := make(map[string]bool)
 
@@ -982,7 +991,7 @@ func Rotate(cfg *config.Config, oldIdentity age.Identity, newRecipient age.Recip
 		return 0, fmt.Errorf("loading manifest: %w", err)
 	}
 	if manifest == nil {
-		return 0, fmt.Errorf("no manifest found")
+		return 0, noManifestErr(sealDir)
 	}
 
 	total := len(manifest.Files)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -155,10 +155,13 @@ func Seal(cfg *config.Config, recipient age.Recipient, verbose bool, progress Pr
 		return stats, fmt.Errorf("loading manifest: %w", err)
 	}
 	prior := map[string]FileEntry{}
+	existed := manifest != nil
+	var priorDeviceID, priorOriginHome string
 	if manifest == nil {
 		manifest = NewManifest(cfg.Seal.DeviceID)
 	} else {
 		maps.Copy(prior, manifest.Files)
+		priorDeviceID, priorOriginHome = manifest.DeviceID, manifest.OriginHome
 	}
 	manifest.DeviceID = cfg.Seal.DeviceID
 	manifest.OriginHome = homeDir(cfg.Seal.ClaudeDir)
@@ -198,9 +201,15 @@ func Seal(cfg *config.Config, recipient age.Recipient, verbose bool, progress Pr
 	trackDeleted(manifest, seen, verbose, &stats)
 	tallySessions(manifest, prior, &stats)
 
-	// Save manifest
-	if err := manifest.Save(sealDir); err != nil {
-		return stats, fmt.Errorf("saving manifest: %w", err)
+	// Persist only when something real changed (content, first seal, or a
+	// DeviceID/OriginHome refresh): Save rewrites sealed_at, and a
+	// timestamp-only rewrite hands the staged-diff commit gate a manifest
+	// change, turning every scheduled no-op seal into a commit.
+	if stats.HasChanges() || !existed ||
+		manifest.DeviceID != priorDeviceID || manifest.OriginHome != priorOriginHome {
+		if err := manifest.Save(sealDir); err != nil {
+			return stats, fmt.Errorf("saving manifest: %w", err)
+		}
 	}
 
 	stats.Elapsed = time.Since(start)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -628,3 +628,68 @@ func TestSeal_ReusesExistingObjectForNewPath(t *testing.T) {
 		t.Errorf("SizeEncrypted = %d, want %d (existing object's size)", entry.SizeEncrypted, len(before))
 	}
 }
+
+// TestRotate_ObjectsButNoManifest covers that Rotate shares the actionable
+// no-manifest diagnosis: a cloned store whose manifest was dropped by a
+// gitignore should steer the user to the recovery steps from every entry
+// point, not just Unseal/Verify.
+func TestRotate_ObjectsButNoManifest(t *testing.T) {
+	identity, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey() error: %v", err)
+	}
+
+	sealDir := t.TempDir()
+	objStore := NewObjectStore(sealDir)
+	if err := objStore.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if err := objStore.Write(ContentHash([]byte("x")), []byte("x")); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.DefaultConfig(t.TempDir(), sealDir)
+
+	_, err = Rotate(cfg, identity, identity.Recipient(), false, nil)
+	if err == nil {
+		t.Fatal("Rotate() with objects but no manifest returned nil error")
+	}
+	for _, want := range []string{"manifest.json", "add -f"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q is missing %q", err.Error(), want)
+		}
+	}
+}
+
+// TestSeal_RefusesFullWipeOnEmptyScan guards against interpreting a zero-file
+// scan as "delete everything": a scan that finds nothing while the manifest is
+// populated is almost always a wrong claude_dir (a synced foreign path, a
+// typo'd --claude-dir), and sealing it would commit a manifest with every
+// entry deleted — which a later unseal propagates as real deletions.
+func TestSeal_RefusesFullWipeOnEmptyScan(t *testing.T) {
+	claudeDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(claudeDir, "CLAUDE.md"), []byte("# hi\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	sealDir := t.TempDir()
+	identity, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey() error: %v", err)
+	}
+	if _, err := Seal(config.DefaultConfig(claudeDir, sealDir), identity.Recipient(), false, nil); err != nil {
+		t.Fatalf("Seal() error: %v", err)
+	}
+
+	badCfg := config.DefaultConfig(filepath.Join(t.TempDir(), "missing", ".claude"), sealDir)
+	_, err = Seal(badCfg, identity.Recipient(), false, nil)
+	if err == nil {
+		t.Fatal("Seal() against a missing claude dir wiped the manifest without error")
+	}
+
+	m, loadErr := LoadManifest(sealDir)
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if len(m.Files) == 0 {
+		t.Error("manifest was emptied despite the refusal")
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -693,3 +693,45 @@ func TestSeal_RefusesFullWipeOnEmptyScan(t *testing.T) {
 		t.Error("manifest was emptied despite the refusal")
 	}
 }
+
+// TestSeal_NoOpLeavesManifestUntouched guards that a seal with no content
+// changes does not rewrite manifest.json: Save refreshes sealed_at, and a
+// timestamp-only rewrite hands the staged-diff commit gate a manifest change,
+// turning every scheduled no-op seal into a commit.
+func TestSeal_NoOpLeavesManifestUntouched(t *testing.T) {
+	claudeDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(claudeDir, "CLAUDE.md"), []byte("# hi\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	sealDir := t.TempDir()
+	identity, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey() error: %v", err)
+	}
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+
+	if _, err := Seal(cfg, identity.Recipient(), false, nil); err != nil {
+		t.Fatalf("first Seal() error: %v", err)
+	}
+	manifestPath := filepath.Join(sealDir, "manifest.json")
+	info1, err := os.Stat(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := Seal(cfg, identity.Recipient(), false, nil)
+	if err != nil {
+		t.Fatalf("second Seal() error: %v", err)
+	}
+	if stats.HasChanges() {
+		t.Fatalf("second seal saw changes: %s", stats)
+	}
+
+	info2, err := os.Stat(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info1.ModTime().Equal(info2.ModTime()) {
+		t.Error("no-op seal rewrote manifest.json (sealed_at churn)")
+	}
+}

--- a/internal/store/unseal_remap_test.go
+++ b/internal/store/unseal_remap_test.go
@@ -236,3 +236,76 @@ func TestUnsealThenSeal_PreservesObjectBytesAcrossDeviceSwitch(t *testing.T) {
 		t.Errorf("foreign key %s still in manifest after re-seal", foreignRel)
 	}
 }
+
+// TestUnseal_DeclinedRemapIsRemembered guards that an interactive "skip" is a
+// remembered decision: the decline persists as a verbatim device-local pin, so
+// the next interactive unseal restores silently instead of re-asking for the
+// same project every time.
+func TestUnseal_DeclinedRemapIsRemembered(t *testing.T) {
+	sealDir, id, foreignRel := sealForeignProject(t)
+
+	prev := DefaultRemapResolver
+	defer func() { DefaultRemapResolver = prev }()
+	calls := 0
+	DefaultRemapResolver = func(plans []RemapPlan) ([]RemapPlan, error) {
+		calls++
+		for i := range plans {
+			plans[i].Accepted = false
+		}
+		return plans, nil
+	}
+
+	dstClaude := filepath.Join(t.TempDir(), ".claude")
+	cfg := config.DefaultConfig(dstClaude, sealDir)
+
+	if _, err := Unseal(cfg, id, false, nil, WithRemap(RemapInteractive)); err != nil {
+		t.Fatalf("Unseal: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("resolver consulted %d times on first unseal, want 1", calls)
+	}
+	if _, err := os.Stat(filepath.Join(dstClaude, foreignRel)); err != nil {
+		t.Errorf("declined project not restored verbatim: %v", err)
+	}
+	src := "-home-daniel-core-enclaude"
+	if got := LoadOverrides(sealDir)[src]; got != src {
+		t.Errorf("decline not pinned: overrides[%s] = %q, want %q", src, got, src)
+	}
+
+	if _, err := Unseal(cfg, id, false, nil, WithRemap(RemapInteractive)); err != nil {
+		t.Fatalf("second Unseal: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("resolver re-consulted after decline was pinned (%d calls)", calls)
+	}
+}
+
+// TestUnseal_PinnedOverrideSkipsPrompt guards that an existing device-local
+// override resolves silently in interactive mode — pins exist so later
+// unseals don't re-ask.
+func TestUnseal_PinnedOverrideSkipsPrompt(t *testing.T) {
+	sealDir, id, _ := sealForeignProject(t)
+
+	src := "-home-daniel-core-enclaude"
+	if err := SaveOverrides(sealDir, map[string]string{src: "-Users-pinned-proj"}); err != nil {
+		t.Fatal(err)
+	}
+
+	prev := DefaultRemapResolver
+	defer func() { DefaultRemapResolver = prev }()
+	DefaultRemapResolver = func(plans []RemapPlan) ([]RemapPlan, error) {
+		t.Error("resolver consulted despite all plans being pinned")
+		return plans, nil
+	}
+
+	dstClaude := filepath.Join(t.TempDir(), ".claude")
+	cfg := config.DefaultConfig(dstClaude, sealDir)
+
+	if _, err := Unseal(cfg, id, false, nil, WithRemap(RemapInteractive)); err != nil {
+		t.Fatalf("Unseal: %v", err)
+	}
+	pinnedPath := filepath.Join(dstClaude, "projects", "-Users-pinned-proj", "a.jsonl")
+	if _, err := os.Stat(pinnedPath); err != nil {
+		t.Errorf("pinned target %s not restored: %v", pinnedPath, err)
+	}
+}


### PR DESCRIPTION
## What

Six small hardening follow-ups from the #95 review (the two big items shipped in #95's hook fix and #100's object reuse):

1. **Commit gating** — `seal`/`sync`/`push` and the session-end hook gated the commit on the seal's own *content* stats, so a deliberate heal run on an unchanged store printed "No changes to commit" and never committed a gitignore-rescued `manifest.json`. New `commitSealStore` helper: always `AddAll`, commit iff anything is actually staged.
2. **`seal.toml` force-staged** — a global `*.toml` rule could keep the config out of the pushed repo; a clone then fails at `config.Load` before unseal even looks for the manifest.
3. **Full-wipe guard in `Seal`** — a zero-file scan against a populated manifest (wrong `claude_dir`: synced foreign path, typo'd flag) now errors instead of tracking every entry as deleted. Belt-and-suspenders for the class of bug fixed in #95's hook commit.
4. **`Rotate` recovery message** — shares `noManifestErr`'s actionable guidance instead of the bare "no manifest found".
5. **`project list` honesty** — foreign classification now consults `manifest.OriginHome` like `PlanRemap`, so homes outside the `-Users/-home/-root` heuristic (e.g. `/var/home/x`) no longer display as "local".
6. **Interactive remap memory** — pinned overrides resolved silently instead of re-prompting, and declines persist as verbatim pins (`src → src`). Previously every interactive unseal re-asked about every foreign project, despite the README's "remembered per-device" promise. `project unmap` undoes a pin.

## Tests

All six written first, each failing on `main` with its bug's signature: `TestAddAll_ForceStagesIgnoredSealToml`, `TestCommitSealStore_RescuesIgnoredMetadataWithoutContentChanges`, `TestRotate_ObjectsButNoManifest`, `TestSeal_RefusesFullWipeOnEmptyScan`, `TestProjectDirs_OriginHomeMarksUnrecognizedForeign`, `TestUnseal_DeclinedRemapIsRemembered`, `TestUnseal_PinnedOverrideSkipsPrompt`.

`go test ./... -count=1` green · `gofmt -l` clean · `go vet` clean · `make build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)