### PR TITLE
🛡️ Sentinel: pin protocol.ext.allow=never on fetch/pull/push

### DIFF
--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -169,7 +169,8 @@ func (g *Git) pushWithArgs(remote, branch string, setUpstream bool) (PushStats, 
 	}
 	stats.Commits = commits
 
-	args := []string{"push", "--porcelain"}
+	// Pin ext:: off (as in Fetch) so a poisoned remote URL can't run a command.
+	args := []string{"-c", "protocol.ext.allow=never", "push", "--porcelain"}
 	if setUpstream {
 		args = append(args, "-u")
 	}
@@ -189,7 +190,11 @@ func (g *Git) pushWithArgs(remote, branch string, setUpstream bool) (PushStats, 
 
 // Fetch fetches from the given remote.
 func (g *Git) Fetch(remote string) (string, error) {
-	return g.run("fetch", "--", remote)
+	// -c protocol.ext.allow=never overrides the user's ambient git policy so a
+	// remote URL git resolves from config can't run the command-executing ext::
+	// transport. rejectUnsafeRemoteURL is the argument-level half of this guard;
+	// it can't see a name->URL resolution, so the policy is pinned here.
+	return g.run("-c", "protocol.ext.allow=never", "fetch", "--", remote)
 }
 
 // Pull pulls from the given remote and branch and returns a PullStats
@@ -207,8 +212,10 @@ func (g *Git) Pull(remote, branch string) (PullStats, string, error) {
 	// the human-friendly form, and the merge driver's stderr arrives
 	// interleaved with stdout — both ends up in the same string for the
 	// parser. Color is suppressed via -c flags. The -- separator keeps a
-	// dash-prefixed remote/branch from being parsed as a git option.
-	cmd := exec.Command(getGitPath(), append([]string{"-C", g.dir, "-c", "color.ui=never", "pull", "--"}, remote, branch)...)
+	// dash-prefixed remote/branch from being parsed as a git option, and
+	// protocol.ext.allow=never pins ext:: off (as in Fetch) so a poisoned
+	// remote URL can't run a command.
+	cmd := exec.Command(getGitPath(), append([]string{"-C", g.dir, "-c", "color.ui=never", "-c", "protocol.ext.allow=never", "pull", "--"}, remote, branch)...)
 	rawOut, err := cmd.CombinedOutput()
 	out := strings.TrimSpace(string(rawOut))
 

--- a/internal/gitops/git_test.go
+++ b/internal/gitops/git_test.go
@@ -855,3 +855,85 @@ func TestAddAll_ForceStagesIgnoredSealToml(t *testing.T) {
 		t.Errorf("seal.toml was not staged despite ignore rule; git ls-files = %q", out)
 	}
 }
+
+// TestRemoteOps_RejectExtTransportFromPoisonedConfig closes the config-
+// resolution RCE vector: a remote whose URL is git's command-executing ext::
+// transport, written straight into .git/config (bypassing the guarded
+// RemoteAdd), must not run its payload when git resolves it by name during
+// fetch/pull/push. The argument-level rejectUnsafeRemoteURL guard can't catch
+// this — callers pass the remote name "origin", not the URL.
+//
+// Modern git already refuses ext:: by default, so the test sets
+// protocol.ext.allow=user in the repo config to recreate the vulnerable
+// condition (an older git, or a user who opted into ext:: globally). The fix
+// must pin protocol.ext.allow=never on git's command line, which overrides
+// that config; each op asserts the sentinel file the payload would touch
+// never appears.
+func TestRemoteOps_RejectExtTransportFromPoisonedConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		op   func(g *Git) error
+	}{
+		{"Fetch", func(g *Git) error { _, err := g.Fetch("origin"); return err }},
+		{"Pull", func(g *Git) error { _, _, err := g.Pull("origin", "main"); return err }},
+		{"Push", func(g *Git) error { _, _, err := g.Push("origin", "main"); return err }},
+		{"PushWithUpstream", func(g *Git) error { _, _, err := g.PushWithUpstream("origin", "main"); return err }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			g := New(dir)
+			if err := g.Init(); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := g.run("config", "user.name", "Test User"); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := g.run("config", "user.email", "test@example.com"); err != nil {
+				t.Fatal(err)
+			}
+			// Recreate the vulnerable ambient policy the fix must override.
+			if _, err := g.run("config", "protocol.ext.allow", "user"); err != nil {
+				t.Fatal(err)
+			}
+			// A commit on a branch named main so push/pull have a real ref and
+			// reach the transport (where the ext payload would fire) rather than
+			// bailing earlier on a missing ref.
+			if err := os.WriteFile(filepath.Join(dir, "f"), []byte("x"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := g.AddAll(); err != nil {
+				t.Fatal(err)
+			}
+			if err := g.Commit("init"); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := g.run("branch", "-M", "main"); err != nil {
+				t.Fatal(err)
+			}
+
+			// The payload: a self-contained executable the ext:: transport runs
+			// on connect. Pointing ext:: at one no-arg script sidesteps the
+			// transport's space-splitting of inline commands.
+			pwned := filepath.Join(dir, "PWNED")
+			helper := filepath.Join(dir, "helper.sh")
+			if err := os.WriteFile(helper, []byte("#!/bin/sh\ntouch "+pwned+"\n"), 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			// Poison the config directly, as a hostile synced store would —
+			// this never passes through RemoteAdd's rejectUnsafeRemoteURL guard.
+			if _, err := g.run("config", "remote.origin.url", "ext::"+helper); err != nil {
+				t.Fatal(err)
+			}
+
+			// The op is expected to error (transport refused, or later ref
+			// negotiation fails); the security property under test is only that
+			// the payload never ran, so we don't assert on the error itself.
+			_ = tc.op(g)
+
+			if _, err := os.Stat(pwned); err == nil {
+				t.Fatalf("%s executed the ext:: payload (sentinel %s exists); protocol.ext.allow=never not applied", tc.name, pwned)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #102. That PR added `rejectUnsafeRemoteURL` checks at the *argument* level (defense-in-depth for a URL passed straight through). This PR closes the vector #102 explicitly could not: a remote whose URL git resolves **by name from `.git/config`**.

## The vector

`enclaude pull/push/sync` pass the remote **name** (`origin`), gated by `HasRemote`; git resolves `remote.origin.url` internally. So `rejectUnsafeRemoteURL` never sees the URL. If `.git/config` holds:

```
[remote "origin"]
    url = ext::sh -c '<payload>'
```

…written directly (bypassing the guarded `RemoteAdd` — e.g. a hostile **synced store**, since enclaude's whole purpose is syncing a git-backed store across machines), git's `ext::` transport runs `<payload>` as a shell command on connect during fetch/pull/push.

## Reachability (verified, not assumed)

Tested on git 2.50.1:

| Ambient `protocol.ext.allow` | `ext::` from poisoned config | After this fix (`-c …=never`) |
|---|---|---|
| unset (modern git default) | **refused** — `transport 'ext' not allowed` | refused |
| `user` / `always` (older git, or user opt-in) | **payload executes (RCE)** | **refused** |

So modern git is safe by default, but the safety is **inherited from the ambient git config**, not guaranteed by enclaude. A user who set `protocol.ext.allow=user` globally (a legitimate thing people do to use `ext::`) reopens the hole for every enclaude pull. Command-line `-c` overrides the config file, so pinning `protocol.ext.allow=never` on the three remote operations makes enclaude's safety independent of the ambient policy.

## Scope

- Pins `-c protocol.ext.allow=never` on `Fetch`, `pushWithArgs` (covers `Push` + `PushWithUpstream`), and `Pull`, matching the file's existing inline `-c color.ui=never` style.
- **`ext::` only.** `fd::` was considered but it isn't a command-execution transport (it wires git to existing file descriptors), so it's left alone to avoid blocking a transport without a real RCE.

## Test

`TestRemoteOps_RejectExtTransportFromPoisonedConfig` poisons `.git/config` directly, sets `protocol.ext.allow=user` to recreate the vulnerable ambient policy, and asserts the payload's sentinel file never appears across all four ops. Written test-first: it executes the payload (RED) without the fix and is refused (GREEN) with it. Full `go test ./...` (299) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)