### PR TITLE
🛡️ Sentinel: scrub ext from GIT_ALLOW_PROTOCOL for git child processes

### DIFF
--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -68,25 +68,34 @@ func New(repoDir string) *Git {
 // invocations: the scrub is a no-op for local commands and can't be forgotten
 // on a remote one.
 func gitSafeEnv() []string {
-	env := os.Environ()
-	const prefix = "GIT_ALLOW_PROTOCOL="
-	for i, kv := range env {
-		if !strings.HasPrefix(kv, prefix) {
+	return scrubExtAllowProtocol(os.Environ())
+}
+
+// scrubExtAllowProtocol returns env with the ext transport removed from every
+// GIT_ALLOW_PROTOCOL entry, dropping any entry whose allowlist it empties so
+// config governs rather than denying all protocols. The variable name is
+// matched case-insensitively: on Windows env names are case-insensitive, so a
+// hostile git_allow_protocol=ext would otherwise reach git as GIT_ALLOW_PROTOCOL
+// and re-enable ext::. The original name's case is preserved.
+func scrubExtAllowProtocol(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		name, val, ok := strings.Cut(kv, "=")
+		if !ok || !strings.EqualFold(name, "GIT_ALLOW_PROTOCOL") {
+			out = append(out, kv)
 			continue
 		}
 		var kept []string
-		for p := range strings.SplitSeq(kv[len(prefix):], ":") {
+		for p := range strings.SplitSeq(val, ":") {
 			if p != "" && p != "ext" {
 				kept = append(kept, p)
 			}
 		}
-		if len(kept) == 0 {
-			return append(env[:i:i], env[i+1:]...)
+		if len(kept) > 0 {
+			out = append(out, name+"="+strings.Join(kept, ":"))
 		}
-		env[i] = prefix + strings.Join(kept, ":")
-		return env
 	}
-	return env
+	return out
 }
 
 // run executes a git command and returns combined output. Use this for

--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -57,10 +57,43 @@ func New(repoDir string) *Git {
 	return &Git{dir: repoDir}
 }
 
+// gitSafeEnv returns os.Environ with the ext transport stripped from any
+// GIT_ALLOW_PROTOCOL entry. That variable is an allowlist that overrides
+// protocol.<name>.allow config — including the -c protocol.ext.allow=never the
+// remote ops pass — so a user (or hostile parent process) exporting
+// GIT_ALLOW_PROTOCOL with ext in it could otherwise re-enable the command-
+// executing ext:: transport for a remote URL git resolves from config. If
+// stripping ext empties the allowlist the variable is dropped so config governs,
+// rather than an empty list that would deny every protocol. Applied to all git
+// invocations: the scrub is a no-op for local commands and can't be forgotten
+// on a remote one.
+func gitSafeEnv() []string {
+	env := os.Environ()
+	const prefix = "GIT_ALLOW_PROTOCOL="
+	for i, kv := range env {
+		if !strings.HasPrefix(kv, prefix) {
+			continue
+		}
+		var kept []string
+		for p := range strings.SplitSeq(kv[len(prefix):], ":") {
+			if p != "" && p != "ext" {
+				kept = append(kept, p)
+			}
+		}
+		if len(kept) == 0 {
+			return append(env[:i:i], env[i+1:]...)
+		}
+		env[i] = prefix + strings.Join(kept, ":")
+		return env
+	}
+	return env
+}
+
 // run executes a git command and returns combined output. Use this for
 // user-facing diagnostics where interleaved stdout/stderr is acceptable.
 func (g *Git) run(args ...string) (string, error) {
 	cmd := exec.Command(getGitPath(), append([]string{"-C", g.dir}, args...)...)
+	cmd.Env = gitSafeEnv()
 	out, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(out)), err
 }
@@ -71,6 +104,7 @@ func (g *Git) run(args ...string) (string, error) {
 func (g *Git) runSeparate(args ...string) (stdout, stderr string, err error) {
 	full := append([]string{"-C", g.dir, "-c", "color.ui=never"}, args...)
 	cmd := exec.Command(getGitPath(), full...)
+	cmd.Env = gitSafeEnv()
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf
@@ -225,6 +259,7 @@ func (g *Git) Pull(remote, branch string) (PullStats, string, error) {
 	// protocol.ext.allow=never pins ext:: off (as in Fetch) so a poisoned
 	// remote URL can't run a command.
 	cmd := exec.Command(getGitPath(), append([]string{"-C", g.dir, "-c", "color.ui=never", "-c", "protocol.ext.allow=never", "pull", "--"}, remote, branch)...)
+	cmd.Env = gitSafeEnv()
 	rawOut, err := cmd.CombinedOutput()
 	out := strings.TrimSpace(string(rawOut))
 

--- a/internal/gitops/git_test.go
+++ b/internal/gitops/git_test.go
@@ -3,6 +3,7 @@ package gitops
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -993,5 +994,63 @@ func TestUnsafeRemoteExecution(t *testing.T) {
 	// PushWithUpstream
 	if _, _, err := g.PushWithUpstream(unsafeRemote, "main"); err == nil || !strings.Contains(err.Error(), "ext::") {
 		t.Errorf("PushWithUpstream expected to fail on ext:: remote, got %v", err)
+	}
+}
+
+// TestScrubExtAllowProtocol verifies the GIT_ALLOW_PROTOCOL scrub removes the
+// ext transport regardless of the variable name's case — env names are case-
+// insensitive on Windows, so a lowercase git_allow_protocol=ext would otherwise
+// slip past and re-enable ext:: — across every matching entry, while leaving
+// other protocols and unrelated variables untouched. A real-git integration
+// test can't exercise the case-insensitive path on Linux/macOS (env names are
+// case-sensitive there), so the pure scrub is asserted directly.
+func TestScrubExtAllowProtocol(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "uppercase strips ext keeps others",
+			in:   []string{"GIT_ALLOW_PROTOCOL=https:ext:ssh"},
+			want: []string{"GIT_ALLOW_PROTOCOL=https:ssh"},
+		},
+		{
+			name: "lowercase name is scrubbed (Windows)",
+			in:   []string{"git_allow_protocol=ext"},
+			want: []string{},
+		},
+		{
+			name: "mixed case name preserved, ext removed",
+			in:   []string{"Git_Allow_Protocol=ext:https"},
+			want: []string{"Git_Allow_Protocol=https"},
+		},
+		{
+			name: "ext-only entry dropped",
+			in:   []string{"PATH=/bin", "GIT_ALLOW_PROTOCOL=ext"},
+			want: []string{"PATH=/bin"},
+		},
+		{
+			name: "no ext left untouched",
+			in:   []string{"GIT_ALLOW_PROTOCOL=https:ssh"},
+			want: []string{"GIT_ALLOW_PROTOCOL=https:ssh"},
+		},
+		{
+			name: "unrelated vars pass through",
+			in:   []string{"PATH=/bin", "HOME=/root"},
+			want: []string{"PATH=/bin", "HOME=/root"},
+		},
+		{
+			name: "every matching entry scrubbed",
+			in:   []string{"GIT_ALLOW_PROTOCOL=ext:https", "git_allow_protocol=ext"},
+			want: []string{"GIT_ALLOW_PROTOCOL=https"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scrubExtAllowProtocol(append([]string{}, tc.in...))
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("scrubExtAllowProtocol(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/gitops/git_test.go
+++ b/internal/gitops/git_test.go
@@ -856,6 +856,60 @@ func TestAddAll_ForceStagesIgnoredSealToml(t *testing.T) {
 	}
 }
 
+// extRemoteOps is the set of remote operations that resolve a remote by name
+// and must refuse git's command-executing ext:: transport.
+var extRemoteOps = []struct {
+	name string
+	op   func(g *Git) error
+}{
+	{"Fetch", func(g *Git) error { _, err := g.Fetch("origin"); return err }},
+	{"Pull", func(g *Git) error { _, _, err := g.Pull("origin", "main"); return err }},
+	{"Push", func(g *Git) error { _, _, err := g.Push("origin", "main"); return err }},
+	{"PushWithUpstream", func(g *Git) error { _, _, err := g.PushWithUpstream("origin", "main"); return err }},
+}
+
+// newPoisonedExtRepo returns a repo with one commit on main whose origin URL is
+// an ext:: payload that touches the returned sentinel path if git ever runs it.
+// The URL is written straight into config, bypassing RemoteAdd's guard, as a
+// hostile synced store would. A no-arg helper script sidesteps the ext::
+// transport's space-splitting of inline commands; the commit gives push/pull a
+// real ref so they reach the transport rather than bailing on a missing ref.
+func newPoisonedExtRepo(t *testing.T) (g *Git, sentinel string) {
+	t.Helper()
+	dir := t.TempDir()
+	g = New(dir)
+	if err := g.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := g.run("config", "user.name", "Test User"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := g.run("config", "user.email", "test@example.com"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "f"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.AddAll(); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Commit("init"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := g.run("branch", "-M", "main"); err != nil {
+		t.Fatal(err)
+	}
+	sentinel = filepath.Join(dir, "PWNED")
+	helper := filepath.Join(dir, "helper.sh")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\ntouch "+sentinel+"\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := g.run("config", "remote.origin.url", "ext::"+helper); err != nil {
+		t.Fatal(err)
+	}
+	return g, sentinel
+}
+
 // TestRemoteOps_RejectExtTransportFromPoisonedConfig closes the config-
 // resolution RCE vector: a remote whose URL is git's command-executing ext::
 // transport, written straight into .git/config (bypassing the guarded
@@ -870,69 +924,38 @@ func TestAddAll_ForceStagesIgnoredSealToml(t *testing.T) {
 // that config; each op asserts the sentinel file the payload would touch
 // never appears.
 func TestRemoteOps_RejectExtTransportFromPoisonedConfig(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		op   func(g *Git) error
-	}{
-		{"Fetch", func(g *Git) error { _, err := g.Fetch("origin"); return err }},
-		{"Pull", func(g *Git) error { _, _, err := g.Pull("origin", "main"); return err }},
-		{"Push", func(g *Git) error { _, _, err := g.Push("origin", "main"); return err }},
-		{"PushWithUpstream", func(g *Git) error { _, _, err := g.PushWithUpstream("origin", "main"); return err }},
-	} {
+	for _, tc := range extRemoteOps {
 		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			g := New(dir)
-			if err := g.Init(); err != nil {
-				t.Fatal(err)
-			}
-			if _, err := g.run("config", "user.name", "Test User"); err != nil {
-				t.Fatal(err)
-			}
-			if _, err := g.run("config", "user.email", "test@example.com"); err != nil {
-				t.Fatal(err)
-			}
+			g, sentinel := newPoisonedExtRepo(t)
 			// Recreate the vulnerable ambient policy the fix must override.
 			if _, err := g.run("config", "protocol.ext.allow", "user"); err != nil {
 				t.Fatal(err)
 			}
-			// A commit on a branch named main so push/pull have a real ref and
-			// reach the transport (where the ext payload would fire) rather than
-			// bailing earlier on a missing ref.
-			if err := os.WriteFile(filepath.Join(dir, "f"), []byte("x"), 0644); err != nil {
-				t.Fatal(err)
-			}
-			if err := g.AddAll(); err != nil {
-				t.Fatal(err)
-			}
-			if err := g.Commit("init"); err != nil {
-				t.Fatal(err)
-			}
-			if _, err := g.run("branch", "-M", "main"); err != nil {
-				t.Fatal(err)
-			}
-
-			// The payload: a self-contained executable the ext:: transport runs
-			// on connect. Pointing ext:: at one no-arg script sidesteps the
-			// transport's space-splitting of inline commands.
-			pwned := filepath.Join(dir, "PWNED")
-			helper := filepath.Join(dir, "helper.sh")
-			if err := os.WriteFile(helper, []byte("#!/bin/sh\ntouch "+pwned+"\n"), 0755); err != nil {
-				t.Fatal(err)
-			}
-
-			// Poison the config directly, as a hostile synced store would —
-			// this never passes through RemoteAdd's rejectUnsafeRemoteURL guard.
-			if _, err := g.run("config", "remote.origin.url", "ext::"+helper); err != nil {
-				t.Fatal(err)
-			}
-
 			// The op is expected to error (transport refused, or later ref
 			// negotiation fails); the security property under test is only that
 			// the payload never ran, so we don't assert on the error itself.
 			_ = tc.op(g)
+			if _, err := os.Stat(sentinel); err == nil {
+				t.Fatalf("%s executed the ext:: payload (sentinel %s exists); protocol.ext.allow=never not applied", tc.name, sentinel)
+			}
+		})
+	}
+}
 
-			if _, err := os.Stat(pwned); err == nil {
-				t.Fatalf("%s executed the ext:: payload (sentinel %s exists); protocol.ext.allow=never not applied", tc.name, pwned)
+// TestRemoteOps_RejectExtViaGitAllowProtocol guards the GIT_ALLOW_PROTOCOL
+// bypass: that variable is an allowlist that overrides protocol.<name>.allow
+// config — including the -c protocol.ext.allow=never the remote ops pass — so a
+// user who exports GIT_ALLOW_PROTOCOL with ext in it would otherwise re-enable
+// the command-executing ext:: transport for a poisoned remote URL. The fix must
+// strip ext from the child environment; each op asserts the payload never ran.
+func TestRemoteOps_RejectExtViaGitAllowProtocol(t *testing.T) {
+	for _, tc := range extRemoteOps {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GIT_ALLOW_PROTOCOL", "ext")
+			g, sentinel := newPoisonedExtRepo(t)
+			_ = tc.op(g)
+			if _, err := os.Stat(sentinel); err == nil {
+				t.Fatalf("%s executed the ext:: payload (sentinel %s exists); GIT_ALLOW_PROTOCOL=ext not scrubbed", tc.name, sentinel)
 			}
 		})
 	}


### PR DESCRIPTION
Addresses roborev job 1232 (codex review of the #103 merge), a Medium finding.

## The gap

#103 pinned `-c protocol.ext.allow=never` on fetch/pull/push to block git's command-executing `ext::` transport for a remote URL resolved by name from `.git/config`. But that flag only overrides git **config**. `GIT_ALLOW_PROTOCOL` is an environment-variable **allowlist** that takes precedence over config, so a user (or a hostile parent process) that exports it with `ext` in the list re-enables `ext::` despite the `-c` flag.

Verified on git 2.50.1: with a poisoned `remote.origin.url = ext::<payload>`,

```
GIT_ALLOW_PROTOCOL=ext git -c protocol.ext.allow=never fetch origin   # → payload executes
```

## Fix

`gitSafeEnv()` returns `os.Environ` with `ext` stripped from any `GIT_ALLOW_PROTOCOL` entry (and drops the variable entirely if that empties the allowlist, so config governs rather than denying every protocol). It's set as `cmd.Env` on every git invocation — in `run`, `runSeparate`, and `Pull`'s inline command. Applying it everywhere makes the scrub a no-op for local commands and impossible to forget on a remote one.

## Test

`TestRemoteOps_RejectExtViaGitAllowProtocol` sets `GIT_ALLOW_PROTOCOL=ext`, poisons the config, and asserts the payload's sentinel never appears across fetch/pull/push. Written test-first: RED (payload executes) without the scrub, GREEN with it. The shared poisoned-repo setup is now a `newPoisonedExtRepo` helper reused by both ext regression tests. Full `go test ./...` (305) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)