### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Manifest Unseal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Git remote operations (`pull`, `push`, `fetch`) via `exec.Command` allowed direct arbitrary command execution via `ext::` protocols and `-` flags injected as remote positional parameters (even after `--`).
 **Learning:** Checking remote validity only on `remote add` or `set-url` is insufficient, because commands that accept the remote dynamically via parameters (e.g., `enclaude sync ext::sh...`) bypass the remote configuration validation.
 **Prevention:** Validate remote input inline within every Git operation method (`Fetch`, `Pull`, `Push`, `PushWithUpstream`) by ensuring inputs are passed to a centralized validation function like `rejectUnsafeRemoteURL` before execution.
+## 2025-02-23 - Prevent Path Traversal in Unseal and Repair
+**Vulnerability:** The `Unseal` and `Repair` operations read `relPath` directly from `manifest.json` and joined it with `ClaudeDir` without checking if it escapes the directory. This could allow an attacker with a manipulated repository or manifest to write arbitrary files (Path Traversal/ZipSlip variant) outside `ClaudeDir`.
+**Learning:** Always validate relative paths read from externally provided manifests or archives before joining them with base directories.
+**Prevention:** Use `filepath.IsLocal` to verify that external paths do not escape the expected directory boundaries before acting on them.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -469,6 +469,14 @@ func Unseal(cfg *config.Config, identity age.Identity, verbose bool, progress Pr
 		}
 		absPath := filepath.Join(cfg.Seal.ClaudeDir, relPath)
 
+		if !filepath.IsLocal(relPath) {
+			stats.Errors++
+			if verbose {
+				fmt.Fprintf(os.Stderr, "  warning: skipping invalid path %s\n", relPath)
+			}
+			continue
+		}
+
 		// Fast path: check size and mtime before reading the entire file and hashing
 		if info, err := os.Stat(absPath); err == nil && entry.ModTimeNs != 0 {
 			if info.Size() == entry.SizePlaintext && info.ModTime().UnixNano() == entry.ModTimeNs {
@@ -909,6 +917,9 @@ func Repair(cfg *config.Config, identity age.Identity, deleteOrphans bool, verbo
 	// Try to fix missing/corrupt by re-sealing from plaintext
 	for _, path := range append(result.MissingObjects, result.CorruptObjects...) {
 		absPath := filepath.Join(cfg.Seal.ClaudeDir, path)
+		if !filepath.IsLocal(path) {
+			continue
+		}
 		plaintext, err := os.ReadFile(absPath)
 		if err != nil {
 			continue // plaintext not available

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,40 @@ import (
 	"github.com/coredipper/enclaude/internal/config"
 	"github.com/coredipper/enclaude/internal/crypto"
 )
+
+func TestUnsealPathTraversal(t *testing.T) {
+	parent := t.TempDir()
+	claudeDir := filepath.Join(parent, "claude")
+	sealDir := filepath.Join(parent, "seal")
+	os.MkdirAll(claudeDir, 0700)
+	os.MkdirAll(sealDir, 0700)
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+
+	manifest := Manifest{
+		Version:  2,
+		DeviceID: "device-1",
+		SealedAt: time.Now().UTC().Format(time.RFC3339),
+		Files: map[string]FileEntry{
+			"../hacked.txt": {ContentHash: "fakehash"},
+		},
+	}
+	data, _ := json.Marshal(manifest)
+	os.WriteFile(filepath.Join(sealDir, "manifest.json"), data, 0644)
+
+	stats, err := Unseal(cfg, identity, false, nil)
+	if err != nil {
+		t.Fatalf("Unseal() error: %v", err)
+	}
+
+	if stats.Errors != 1 {
+		t.Errorf("expected 1 error due to path traversal, got %d", stats.Errors)
+	}
+	if _, err := os.Stat(filepath.Join(parent, "hacked.txt")); err == nil {
+		t.Error("path traversal successful, file should not exist")
+	}
+}
 
 func TestSealUnsealRoundTrip(t *testing.T) {
 	// Create source directory (simulated ~/.claude/)


### PR DESCRIPTION
🛡️ **Sentinel: [CRITICAL] Fix Path Traversal in Unseal/Repair**

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `Unseal` and `Repair` operations read `relPath` directly from `manifest.json` and joined it with `ClaudeDir` using `filepath.Join()`. This allowed a malicious or tampered manifest to include relative paths like `../../../etc/passwd`, resulting in arbitrary file write or overwrite outside of the target `.claude` directory during restoration.
🎯 **Impact:** An attacker who manipulates the Git repository or manifest.json could gain arbitrary file write access on the target machine when the user pulls and unseals the data.
🔧 **Fix:** Added `filepath.IsLocal(relPath)` validation in both `Unseal` and `Repair` to strictly ensure the path resolves safely within the base directory. Added comprehensive test coverage in `TestUnsealPathTraversal` to prevent future regressions.
✅ **Verification:** Verified via test suite run (`go test ./...`) with the path traversal prevention explicitly asserted to fail securely.

---
*PR created automatically by Jules for task [14831320776337272579](https://jules.google.com/task/14831320776337272579) started by @coredipper*