### PR TITLE
🧪 test(store): cover Repair path-traversal guard

### DIFF
--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -47,6 +47,55 @@ func TestUnsealPathTraversal(t *testing.T) {
 	}
 }
 
+// TestRepairPathTraversal guards Repair's re-seal loop against a manifest key
+// that escapes ClaudeDir ("../secret.txt"). Without the filepath.IsLocal check,
+// Repair reads the external file, encrypts it into the object store, and records
+// it in the manifest — an arbitrary-file exfiltration vector. The guard must
+// skip the entry so the external file's bytes never enter the store.
+func TestRepairPathTraversal(t *testing.T) {
+	parent := t.TempDir()
+	claudeDir := filepath.Join(parent, "claude")
+	sealDir := filepath.Join(parent, "seal")
+	os.MkdirAll(claudeDir, 0700)
+	os.MkdirAll(sealDir, 0700)
+
+	// Secret outside ClaudeDir; the manifest key "../secret.txt" resolves here.
+	secret := []byte("top secret outside claude dir")
+	if err := os.WriteFile(filepath.Join(parent, "secret.txt"), secret, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+
+	// The hash is absent from the store, so Verify flags the entry as a missing
+	// object and Repair attempts to re-seal it from plaintext.
+	manifest := Manifest{
+		Version:  2,
+		DeviceID: "device-1",
+		SealedAt: time.Now().UTC().Format(time.RFC3339),
+		Files: map[string]FileEntry{
+			"../secret.txt": {ContentHash: strings.Repeat("0", 64)},
+		},
+	}
+	data, _ := json.Marshal(manifest)
+	if err := os.WriteFile(filepath.Join(sealDir, "manifest.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Repair(cfg, identity, false, false)
+	if err != nil {
+		t.Fatalf("Repair() error: %v", err)
+	}
+
+	if result.Fixed != 0 {
+		t.Errorf("traversal entry was repaired (Fixed=%d), want 0", result.Fixed)
+	}
+	if NewObjectStore(sealDir).Exists(ContentHash(secret)) {
+		t.Error("external file was read and sealed into the store — traversal not blocked")
+	}
+}
+
 func TestSealUnsealRoundTrip(t *testing.T) {
 	// Create source directory (simulated ~/.claude/)
 	claudeDir := setupTestDir(t)


### PR DESCRIPTION
## What

Adds `TestRepairPathTraversal`, a regression test for the `filepath.IsLocal` guard merged in #106.

#106 added the guard to **both** `Unseal` and `Repair`, but shipped a test only for `Unseal`. The `Repair` branch is the more interesting vector — it's an arbitrary-file **read/exfiltration**, not just an out-of-tree write: without the guard, a manifest key like `../secret.txt` makes `Verify` flag a missing object, then `Repair` reads the external file, encrypts it into the object store, and records it in the manifest.

## The test

Drives `Repair` with a `../secret.txt` manifest key pointing at a secret outside `ClaudeDir`, and asserts:
- `result.Fixed == 0` — the traversal entry was not "repaired"
- the secret's content hash is **not** present in the object store — its bytes never got sealed

## Verification (TDD)

- **RED** (guard removed): fails — `Fixed=1` and the secret is sealed into the store.
- **GREEN** (guard restored): passes.
- Full suite: `go test ./... -count=1` → 315 passed across 9 packages; `go vet ./internal/store/` clean.

Test-only change — no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)