### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Git Flag Injection in Refs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The `Unseal` and `Repair` operations read `relPath` directly from `manifest.json` and joined it with `ClaudeDir` without checking if it escapes the directory. This could allow an attacker with a manipulated repository or manifest to write arbitrary files (Path Traversal/ZipSlip variant) outside `ClaudeDir`.
 **Learning:** Always validate relative paths read from externally provided manifests or archives before joining them with base directories.
 **Prevention:** Use `filepath.IsLocal` to verify that external paths do not escape the expected directory boundaries before acting on them.
+## 2026-06-17 - Prevent Git Flag Injection in Refs
+**Vulnerability:** Git operations (`checkout`, `merge`, `show`) accepted user-provided refs directly via `exec.Command`. A ref starting with a dash (e.g., `-p`, `--orphan`) could be interpreted as a Git option instead of a ref, allowing flag injection.
+**Learning:** The `--` separator does not protect against positional arguments that Git expects to be refs but which start with `-` (e.g., in `git checkout <ref>`, if `<ref>` is `--orphan`, Git parses it as an option). Even when using `--` later in the command line (e.g., `git checkout <ref> -- <file>`), the `<ref>` parameter itself is evaluated before the `--`.
+**Prevention:** Always explicitly validate and reject user-provided Git refs that start with a dash before passing them to `exec.Command`.

--- a/internal/gitops/git.go
+++ b/internal/gitops/git.go
@@ -292,8 +292,20 @@ func (g *Git) Pull(remote, branch string) (PullStats, string, error) {
 	return stats, out, err
 }
 
+// rejectUnsafeRef blocks refs that start with a dash to prevent flag
+// injection vulnerabilities when passed to git commands.
+func rejectUnsafeRef(ref string) error {
+	if strings.HasPrefix(ref, "-") {
+		return fmt.Errorf("refusing ref starting with dash (flag injection risk): %s", ref)
+	}
+	return nil
+}
+
 // Merge merges the given ref into the current branch.
 func (g *Git) Merge(ref string) (string, error) {
+	if err := rejectUnsafeRef(ref); err != nil {
+		return "", err
+	}
 	return g.run("merge", "--", ref)
 }
 
@@ -435,11 +447,17 @@ func (g *Git) HasUpstream() bool {
 
 // ShowFileAtRef returns the contents of a file at a specific git ref.
 func (g *Git) ShowFileAtRef(ref, path string) (string, error) {
+	if err := rejectUnsafeRef(ref); err != nil {
+		return "", err
+	}
 	return g.run("show", ref+":"+path)
 }
 
 // Checkout restores files from a specific ref.
 func (g *Git) Checkout(ref string, paths ...string) (string, error) {
+	if err := rejectUnsafeRef(ref); err != nil {
+		return "", err
+	}
 	args := append([]string{"checkout", ref, "--"}, paths...)
 	return g.run(args...)
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Git operations (`checkout`, `merge`, `show`) accepted user-provided refs directly. A ref starting with a dash (e.g., `--orphan`, `-p`) could be interpreted as a Git option instead of a ref, allowing flag injection. Even with the `--` separator, positional arguments before the separator are evaluated as options if they start with a dash.
🎯 **Impact:** An attacker or malicious input could alter the behavior of Git commands, potentially checking out orphaned branches, patching files unexpectedly, or exposing sensitive data.
🔧 **Fix:** Added a `rejectUnsafeRef` validation function to `internal/gitops/git.go` that blocks any ref starting with a dash. Applied this validation to the `Checkout`, `Merge`, and `ShowFileAtRef` operations.
✅ **Verification:** Verified by checking the updated validation logic and ensuring all unit tests pass with `go test ./...`.

---
*PR created automatically by Jules for task [3589814659656252566](https://jules.google.com/task/3589814659656252566) started by @coredipper*