### PR TITLE
build: align local `make build` version with goreleaser (strip leading `v`)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+# Strip the leading "v" so local builds match goreleaser's {{.Version}}
+# (bare semver). Grouping keeps the "dev" fallback firing on git failure —
+# sed always exits 0, so it must run after the fallback resolves, not in
+# the same pipeline.
+VERSION := $(shell { git describe --tags --always --dirty 2>/dev/null || echo "dev"; } | sed 's/^v//')
 LDFLAGS := -ldflags "-X github.com/coredipper/enclaude/cmd.Version=$(VERSION)"
 
 .PHONY: build install test lint clean


### PR DESCRIPTION
## What

`make build` derived its version from `git describe --tags` (e.g. `v0.8.5`), while goreleaser injects `{{.Version}}` — bare semver (`0.8.5`). Both feed the same `-X …cmd.Version=` ldflag, so `enclaude --version` reported a different string depending on who built it:

- Published release artifact: `enclaude version 0.8.5`
- Local `make build`: `enclaude version v0.8.5`

## Fix

Strip the leading `v` in the Makefile so local builds match the published artifacts (bare semver is the goreleaser/Go-ecosystem convention; the `v` is a git-tag convention, not a version-number one).

The fallback is preserved: `sed` runs *after* the `|| echo "dev"` resolves (grouped in braces), because a piped `sed` always exits 0 and would otherwise swallow the git-failure signal and leave the version empty. `dev` and bare-hash outputs have no leading `v`, so they pass through untouched.

## Verification

```
$ make build && ./enclaude --version
enclaude version 0.8.5      # was: v0.8.5
```

Build-tooling only — does not affect the already-published v0.8.5 artifacts, so no new release is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)