### PR TITLE
Harden plaintext purge and key rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,15 @@ This isn't a bug — it's how every AI coding assistant works today (Cursor, Cop
 
 **Git** provides the transport layer. The encrypted objects are committed to a git repository, giving you full version history, branching, and remote sync — all on encrypted data. Your plaintext never leaves your machine; only encrypted blobs are pushed.
 
+**Purge plaintext** is explicit. By default, `seal` leaves `~/.claude/` in place because Claude Code reads it directly. After sealing, you can remove sealed plaintext session transcripts with `enclaude purge-plaintext`; add `--shred` to overwrite before removal.
+
 ### Why This Works Well for Claude Data
 
 Claude Code's session files have a property that makes sync trivial: **they're immutable after completion**. Once a session ends, its JSONL file is never modified again. This means:
 
 - Two devices that both ran sessions produce different files with different hashes — no conflicts, just union both sides
 - `history.jsonl` is append-only — merging two diverged copies means deduplicating lines and sorting by timestamp
-- Memory files are small markdown — standard 3-way text merge handles them
+- Memory files are small markdown — a simple whole-file 3-way merge handles one-sided edits and writes conflict markers if both sides changed
 
 The only files that need real merge logic are `settings.json` (last-write-wins) and `history.jsonl` (line-level dedup). Everything else is either immutable or trivially mergeable.
 
@@ -148,6 +150,7 @@ This adds `SessionStart` and `SessionEnd` hooks to `~/.claude/settings.json`. Wh
 | `sync` | Seal + pull + push (the daily driver) |
 | `push` | Seal + git push |
 | `pull` | Git pull + merge + unseal |
+| `purge-plaintext` | Remove sealed completed session plaintext from `~/.claude/` |
 
 ### History & Recovery
 | Command | Description |
@@ -174,6 +177,7 @@ This adds `SessionStart` and `SessionEnd` hooks to `~/.claude/settings.json`. Wh
 | `hooks remove` | Remove auto-sync hooks |
 | `hooks status` | Check if hooks are installed |
 | `readme-regen` | Regenerate and commit README.md in the seal store |
+| `purge-plaintext` | Remove sealed completed session plaintext (`--all-managed` removes every matching managed file) |
 | `project list` | List synced project dirs and their local/foreign status |
 | `project map <src> <target>` | Pin a device-local project-key remap |
 | `project unmap <src>` | Remove a pinned project-key remap |
@@ -184,11 +188,11 @@ When pulling from a remote, two devices may have diverged. `enclaude` uses a cus
 
 | Strategy | Used for | How it works |
 |----------|----------|-------------|
-| `immutable` | Session JSONL files | Union both sides — sessions never change after completion, so there are no conflicts |
+| `immutable` | Session JSONL files | Distinct session files are unioned at the manifest level; if the same path diverges unexpectedly, keep the local side |
 | `jsonl_dedup` | `history.jsonl` | Parse each line as JSON, SHA-256 hash for dedup, sort by timestamp |
 | `sessions_index` | `sessions-index.json` | Deduplicate entries by `sessionId`, preserving unique sessions from both sides |
 | `last_write_wins` | `settings.json`, `stats-cache.json` | Keep whichever version has the later modification time |
-| `text_merge` | Memory files (`.md`) | Standard 3-way text merge; conflict markers if both sides changed |
+| `text_merge` | Memory files (`.md`) | Simple whole-file 3-way merge; conflict markers if both sides changed |
 
 These strategies are configurable per path pattern in `seal.toml`.
 
@@ -237,7 +241,7 @@ patterns = [
 
 | Property | Status |
 |----------|--------|
-| Encrypted at rest (between sessions) | Yes — completed session plaintext can be shredded after seal |
+| Encrypted at rest (between sessions) | Encrypted copy yes; local plaintext remains unless you run `purge-plaintext` |
 | Encrypted at rest (during active session) | No — Claude Code requires plaintext to function |
 | Encrypted in transit (git push/pull) | Yes — only age-encrypted blobs are pushed |
 | Key storage | OS keychain (macOS Keychain, Linux secret-service, Windows Credential Manager) |
@@ -248,6 +252,7 @@ patterns = [
 ### Honest Limitations
 
 - **During an active Claude Code session, plaintext exists on disk.** This is unavoidable — Claude Code reads `~/.claude/` directly and cannot be modified to read encrypted data. Use OS-level disk encryption (FileVault, BitLocker, LUKS) for protection during sessions.
+- **Sealing does not delete plaintext.** Run `enclaude purge-plaintext` after a successful seal to remove completed session transcripts, or `enclaude purge-plaintext --all-managed --yes` if you intentionally want to remove every managed plaintext file that still matches the sealed manifest.
 - **Application-level encryption does not protect against a malicious process running as your user.** If an attacker has code execution as your user, they can read decrypted files in memory or extract the key from the keychain. OS-level protections are the right defense layer here.
 - **The encryption key must be shared across devices.** This is inherent to any cross-device sync scheme. Use `key export` to save your key in a password manager, or rely on the passphrase-encrypted `key.age.backup` that travels with the repo.
 - **Cross-device project remap only fixes the directory key.** `unseal` places a synced project where the local Claude Code looks (see [Projects Across Devices](#projects-across-devices)), but absolute paths embedded inside transcripts (cwd, tool arguments) keep the originating machine's paths as a historical record — they are not rewritten, and Claude Code does not re-execute them.
@@ -295,4 +300,3 @@ Your full Claude Code history, memory, and settings appear on the new device, en
 ## License
 
 MIT
-

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This isn't a bug — it's how every AI coding assistant works today (Cursor, Cop
 
 **Git** provides the transport layer. The encrypted objects are committed to a git repository, giving you full version history, branching, and remote sync — all on encrypted data. Your plaintext never leaves your machine; only encrypted blobs are pushed.
 
-**Purge plaintext** is explicit. By default, `seal` leaves `~/.claude/` in place because Claude Code reads it directly. After sealing, you can remove sealed plaintext session transcripts with `enclaude purge-plaintext`; add `--shred` to overwrite before removal.
+**Purge plaintext** is explicit. By default, `seal` leaves `~/.claude/` in place because Claude Code reads it directly. After sealing, you can remove sealed plaintext session transcripts with `enclaude purge-plaintext`; it removes only files whose encrypted object is recoverable. Add `--shred` to overwrite before removal.
 
 ### Why This Works Well for Claude Data
 
@@ -177,7 +177,7 @@ This adds `SessionStart` and `SessionEnd` hooks to `~/.claude/settings.json`. Wh
 | `hooks remove` | Remove auto-sync hooks |
 | `hooks status` | Check if hooks are installed |
 | `readme-regen` | Regenerate and commit README.md in the seal store |
-| `purge-plaintext` | Remove sealed completed session plaintext (`--all-managed` removes every matching managed file) |
+| `purge-plaintext` | Remove sealed completed session plaintext (`--all-managed` removes every recoverable matching managed file) |
 | `project list` | List synced project dirs and their local/foreign status |
 | `project map <src> <target>` | Pin a device-local project-key remap |
 | `project unmap <src>` | Remove a pinned project-key remap |
@@ -252,7 +252,7 @@ patterns = [
 ### Honest Limitations
 
 - **During an active Claude Code session, plaintext exists on disk.** This is unavoidable — Claude Code reads `~/.claude/` directly and cannot be modified to read encrypted data. Use OS-level disk encryption (FileVault, BitLocker, LUKS) for protection during sessions.
-- **Sealing does not delete plaintext.** Run `enclaude purge-plaintext` after a successful seal to remove completed session transcripts, or `enclaude purge-plaintext --all-managed --yes` if you intentionally want to remove every managed plaintext file that still matches the sealed manifest.
+- **Sealing does not delete plaintext.** Run `enclaude purge-plaintext` after a successful seal to remove completed session transcripts, or `enclaude purge-plaintext --all-managed --yes` if you intentionally want to remove every managed plaintext file that still matches a recoverable sealed object.
 - **Application-level encryption does not protect against a malicious process running as your user.** If an attacker has code execution as your user, they can read decrypted files in memory or extract the key from the keychain. OS-level protections are the right defense layer here.
 - **The encryption key must be shared across devices.** This is inherent to any cross-device sync scheme. Use `key export` to save your key in a password manager, or rely on the passphrase-encrypted `key.age.backup` that travels with the repo.
 - **Cross-device project remap only fixes the directory key.** `unseal` places a synced project where the local Claude Code looks (see [Projects Across Devices](#projects-across-devices)), but absolute paths embedded inside transcripts (cwd, tool arguments) keep the originating machine's paths as a historical record — they are not rewritten, and Claude Code does not re-execute them.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -176,7 +176,7 @@ passphrase-encrypted key file under {TICK}$XDG_CONFIG_HOME/enclaude/{TICK}.
    {TICK}git clone <remote-url> ~/.enclaude{TICK}
 3. Import your private key (into the OS keyring if available, otherwise into
    a local passphrase-encrypted key file):
-   {TICK}enclaude key import{TICK}
+   {TICK}enclaude key import --from-backup{TICK} (or {TICK}enclaude key import keyfile.txt{TICK})
 4. Decrypt and restore your Claude files:
    {TICK}enclaude unseal{TICK}
 
@@ -186,7 +186,7 @@ If both the OS keyring entry and the local key file are lost, restore from the
 passphrase-encrypted backup committed to this repository:
 
 {FENCE}
-enclaude key recover key.age.backup
+enclaude key import --from-backup
 {FENCE}
 
 You will be prompted for the passphrase you set during {TICK}enclaude init{TICK}.

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -40,10 +40,14 @@ func TestBuildReadme(t *testing.T) {
 			contains: []string{
 				"## Restoring on a new machine",
 				"## Key recovery",
+				"enclaude key import --from-backup",
 				"## Daily use",
 				"enclaude unseal",
 				"enclaude seal",
 				"Private keys are never stored here",
+			},
+			absent: []string{
+				"enclaude key recover",
 			},
 		},
 		{

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	cryptorand "crypto/rand"
 	"errors"
 	"fmt"
 	"os"
@@ -97,15 +98,50 @@ func writeRotationRecoveryKeys(old, new *age.X25519Identity) (string, error) {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return "", fmt.Errorf("creating recovery key directory: %w", err)
 	}
-	path := filepath.Join(dir, "key-rotation-recovery-"+time.Now().UTC().Format("20060102T150405Z")+".txt")
+	stamp := time.Now().UTC().Format("20060102T150405.000000000Z")
+	var lastErr error
+	for range 16 {
+		suffix, err := randomHex(8)
+		if err != nil {
+			return "", err
+		}
+		path := filepath.Join(dir, "key-rotation-recovery-"+stamp+"-"+suffix+".txt")
+		if err := writeRotationRecoveryKeysFile(path, old, new); err == nil {
+			return path, nil
+		} else if !os.IsExist(err) {
+			return "", err
+		} else {
+			lastErr = err
+		}
+	}
+	return "", fmt.Errorf("creating unique recovery key file: %w", lastErr)
+}
+
+func writeRotationRecoveryKeysFile(path string, old, new *age.X25519Identity) error {
 	content := "# enclaude emergency key rotation recovery\n" +
 		"# Keep this file private. The store may need either key until repair completes.\n" +
 		"old=" + old.String() + "\n" +
 		"new=" + new.String() + "\n"
-	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
-		return "", fmt.Errorf("writing recovery key file: %w", err)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("creating recovery key file: %w", err)
 	}
-	return path, nil
+	if _, err := f.WriteString(content); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("writing recovery key file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("closing recovery key file: %w", err)
+	}
+	return nil
+}
+
+func randomHex(n int) (string, error) {
+	buf := make([]byte, n)
+	if _, err := cryptorand.Read(buf); err != nil {
+		return "", fmt.Errorf("reading random bytes: %w", err)
+	}
+	return fmt.Sprintf("%x", buf), nil
 }
 
 var keyCmd = &cobra.Command{

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bufio"
-	cryptorand "crypto/rand"
 	"errors"
 	"fmt"
 	"os"
@@ -101,7 +100,7 @@ func writeRotationRecoveryKeys(old, new *age.X25519Identity) (string, error) {
 	stamp := time.Now().UTC().Format("20060102T150405.000000000Z")
 	var lastErr error
 	for range 16 {
-		suffix, err := randomHex(8)
+		suffix, err := store.RandomHex(8)
 		if err != nil {
 			return "", err
 		}
@@ -134,14 +133,6 @@ func writeRotationRecoveryKeysFile(path string, old, new *age.X25519Identity) er
 		return fmt.Errorf("closing recovery key file: %w", err)
 	}
 	return nil
-}
-
-func randomHex(n int) (string, error) {
-	buf := make([]byte, n)
-	if _, err := cryptorand.Read(buf); err != nil {
-		return "", fmt.Errorf("reading random bytes: %w", err)
-	}
-	return fmt.Sprintf("%x", buf), nil
 }
 
 var keyCmd = &cobra.Command{

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"filippo.io/age"
 	"github.com/coredipper/enclaude/internal/config"
@@ -21,10 +22,11 @@ import (
 // Injected so tests can verify ordering and failure semantics without touching
 // a real seal store, keyring, or filesystem.
 type keyRotateDeps struct {
-	loadKey  func() (*age.X25519Identity, error)
-	genKey   func() (*age.X25519Identity, error)
-	storeKey func(*age.X25519Identity) error
-	rotate   func(old *age.X25519Identity, newRecipient *age.X25519Recipient) (int, error)
+	loadKey              func() (*age.X25519Identity, error)
+	genKey               func() (*age.X25519Identity, error)
+	storeKey             func(*age.X25519Identity) error
+	rotate               func(old *age.X25519Identity, newRecipient *age.X25519Recipient) (int, error)
+	preserveRecoveryKeys func(old, new *age.X25519Identity) (string, error)
 }
 
 // rotateKeyCore performs key rotation in the only safe order:
@@ -67,11 +69,43 @@ func rotateKeyCore(d keyRotateDeps) (old, new *age.X25519Identity, rotated int, 
 				err = errors.Join(rotationErr, fmt.Errorf("restoring old key after rotation failure: %w", restoreErr))
 				return
 			}
+		} else if store.IsRotationStoreAmbiguous(err) {
+			if d.preserveRecoveryKeys == nil {
+				err = errors.Join(rotationErr, errors.New("rotation key state is ambiguous and no recovery key preservation is configured"))
+				return
+			}
+			recoveryPath, preserveErr := d.preserveRecoveryKeys(old, new)
+			if preserveErr != nil {
+				err = errors.Join(rotationErr, fmt.Errorf("preserving old and new keys for recovery: %w", preserveErr))
+				return
+			}
+			err = errors.Join(rotationErr, fmt.Errorf("saved old and new key material for manual recovery at %s", recoveryPath))
+			return
 		}
 		err = rotationErr
 		return
 	}
 	return
+}
+
+func writeRotationRecoveryKeys(old, new *age.X25519Identity) (string, error) {
+	base, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("locating user config dir: %w", err)
+	}
+	dir := filepath.Join(base, "enclaude")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", fmt.Errorf("creating recovery key directory: %w", err)
+	}
+	path := filepath.Join(dir, "key-rotation-recovery-"+time.Now().UTC().Format("20060102T150405Z")+".txt")
+	content := "# enclaude emergency key rotation recovery\n" +
+		"# Keep this file private. The store may need either key until repair completes.\n" +
+		"old=" + old.String() + "\n" +
+		"new=" + new.String() + "\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		return "", fmt.Errorf("writing recovery key file: %w", err)
+	}
+	return path, nil
 }
 
 var keyCmd = &cobra.Command{
@@ -196,6 +230,7 @@ var keyRotateCmd = &cobra.Command{
 				fmt.Println("Re-encrypting all objects...")
 				return store.Rotate(cfg, old, newRecipient, flagVerbose, nil)
 			},
+			preserveRecoveryKeys: writeRotationRecoveryKeys,
 		}
 
 		oldIdentity, newIdentity, rotated, err := rotateKeyCore(deps)

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -32,12 +33,16 @@ type keyRotateDeps struct {
 //  2. Generate new key.
 //  3. Persist the new key.
 //  4. Re-encrypt all sealed objects to the new key.
+//  5. If re-encryption fails, restore the old key.
 //
 // Persisting BEFORE re-encryption is critical: if storeKey prompts the user
 // (file fallback) and they cancel, or any other persistence failure occurs,
 // the seal store is still intact under the old key. Doing rotate first and
 // then storeKey would leave every object encrypted to a key that exists only
 // in process memory if storeKey fails — total data loss.
+//
+// Rotation itself now fails before overwriting on missing/corrupt objects, so a
+// rotation error after the new key was persisted must put the old key back.
 func rotateKeyCore(d keyRotateDeps) (old, new *age.X25519Identity, rotated int, err error) {
 	old, err = d.loadKey()
 	if err != nil {
@@ -55,7 +60,12 @@ func rotateKeyCore(d keyRotateDeps) (old, new *age.X25519Identity, rotated int, 
 	}
 	rotated, err = d.rotate(old, new.Recipient())
 	if err != nil {
-		err = fmt.Errorf("rotation: %w", err)
+		rotationErr := fmt.Errorf("rotation: %w", err)
+		if restoreErr := d.storeKey(old); restoreErr != nil {
+			err = errors.Join(rotationErr, fmt.Errorf("restoring old key after rotation failure: %w", restoreErr))
+			return
+		}
+		err = rotationErr
 		return
 	}
 	return

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -33,7 +33,7 @@ type keyRotateDeps struct {
 //  2. Generate new key.
 //  3. Persist the new key.
 //  4. Re-encrypt all sealed objects to the new key.
-//  5. If re-encryption fails, restore the old key.
+//  5. If re-encryption fails before object writes survive, restore the old key.
 //
 // Persisting BEFORE re-encryption is critical: if storeKey prompts the user
 // (file fallback) and they cancel, or any other persistence failure occurs,
@@ -41,8 +41,9 @@ type keyRotateDeps struct {
 // then storeKey would leave every object encrypted to a key that exists only
 // in process memory if storeKey fails — total data loss.
 //
-// Rotation itself now fails before overwriting on missing/corrupt objects, so a
-// rotation error after the new key was persisted must put the old key back.
+// Rotation reports whether a failure left the store encrypted with the old key;
+// only then is it safe to restore old key storage. For late failures after
+// object writes, keeping the new key is the least dangerous consistent state.
 func rotateKeyCore(d keyRotateDeps) (old, new *age.X25519Identity, rotated int, err error) {
 	old, err = d.loadKey()
 	if err != nil {
@@ -61,9 +62,11 @@ func rotateKeyCore(d keyRotateDeps) (old, new *age.X25519Identity, rotated int, 
 	rotated, err = d.rotate(old, new.Recipient())
 	if err != nil {
 		rotationErr := fmt.Errorf("rotation: %w", err)
-		if restoreErr := d.storeKey(old); restoreErr != nil {
-			err = errors.Join(rotationErr, fmt.Errorf("restoring old key after rotation failure: %w", restoreErr))
-			return
+		if store.IsRotationStoreUnchanged(err) {
+			if restoreErr := d.storeKey(old); restoreErr != nil {
+				err = errors.Join(rotationErr, fmt.Errorf("restoring old key after rotation failure: %w", restoreErr))
+				return
+			}
 		}
 		err = rotationErr
 		return

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -204,7 +204,9 @@ var keyRotateCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("creating backup: %w", err)
 			}
-			os.WriteFile(filepath.Join(sealDir, "key.age.backup"), backup, 0600)
+			if err := os.WriteFile(filepath.Join(sealDir, "key.age.backup"), backup, 0600); err != nil {
+				return fmt.Errorf("writing key backup: %w", err)
+			}
 			fmt.Println("  Key backup updated.")
 		}
 

--- a/cmd/key_test.go
+++ b/cmd/key_test.go
@@ -246,6 +246,10 @@ func TestRotateKeyCore_RotationFailureKeepsNewKeyWhenStoreMayHaveChanged(t *test
 	}
 }
 
+// TestRotateKeyCore_AmbiguousRotationPreservesRecoveryKeys verifies that when
+// rotation reports an ambiguous object-store state, the core invokes the
+// recovery-key hook with both identities and surfaces the recovery file path in
+// the error, rather than discarding either key.
 func TestRotateKeyCore_AmbiguousRotationPreservesRecoveryKeys(t *testing.T) {
 	tr := &rotateTrace{}
 	oldID := mustGen(t)
@@ -315,6 +319,9 @@ func TestRotateKeyCore_AmbiguousRotationPreservesRecoveryKeys(t *testing.T) {
 	}
 }
 
+// TestWriteRotationRecoveryKeysFileCreatesExclusive0600File verifies the
+// emergency recovery file is created with 0600 permissions and contains both
+// the old and new private keys.
 func TestWriteRotationRecoveryKeysFileCreatesExclusive0600File(t *testing.T) {
 	oldID := mustGen(t)
 	newID := mustGen(t)
@@ -340,6 +347,8 @@ func TestWriteRotationRecoveryKeysFileCreatesExclusive0600File(t *testing.T) {
 	}
 }
 
+// TestWriteRotationRecoveryKeysFileRefusesExistingPath guards the O_EXCL create:
+// an existing path is left untouched rather than overwritten with key material.
 func TestWriteRotationRecoveryKeysFileRefusesExistingPath(t *testing.T) {
 	oldID := mustGen(t)
 	newID := mustGen(t)
@@ -361,6 +370,9 @@ func TestWriteRotationRecoveryKeysFileRefusesExistingPath(t *testing.T) {
 	}
 }
 
+// TestWriteRotationRecoveryKeysFileRefusesSymlinkPath guards against following a
+// symlink at the recovery path, which would write key material to an
+// attacker-chosen target outside the config dir.
 func TestWriteRotationRecoveryKeysFileRefusesSymlinkPath(t *testing.T) {
 	oldID := mustGen(t)
 	newID := mustGen(t)

--- a/cmd/key_test.go
+++ b/cmd/key_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -310,6 +312,78 @@ func TestRotateKeyCore_AmbiguousRotationPreservesRecoveryKeys(t *testing.T) {
 		if tr.calls[i] != c {
 			t.Fatalf("call[%d] = %q, want %q (full: %v)", i, tr.calls[i], c, tr.calls)
 		}
+	}
+}
+
+func TestWriteRotationRecoveryKeysFileCreatesExclusive0600File(t *testing.T) {
+	oldID := mustGen(t)
+	newID := mustGen(t)
+	path := filepath.Join(t.TempDir(), "recovery.txt")
+
+	if err := writeRotationRecoveryKeysFile(path, oldID, newID); err != nil {
+		t.Fatalf("writeRotationRecoveryKeysFile: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat recovery file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("recovery file mode = %v, want 0600", got)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read recovery file: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "old="+oldID.String()) || !strings.Contains(text, "new="+newID.String()) {
+		t.Fatalf("recovery file missing expected keys: %q", text)
+	}
+}
+
+func TestWriteRotationRecoveryKeysFileRefusesExistingPath(t *testing.T) {
+	oldID := mustGen(t)
+	newID := mustGen(t)
+	path := filepath.Join(t.TempDir(), "recovery.txt")
+	original := []byte("do not replace")
+	if err := os.WriteFile(path, original, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeRotationRecoveryKeysFile(path, oldID, newID); err == nil {
+		t.Fatal("expected existing recovery path to fail")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read existing file: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("existing file was modified: got %q", got)
+	}
+}
+
+func TestWriteRotationRecoveryKeysFileRefusesSymlinkPath(t *testing.T) {
+	oldID := mustGen(t)
+	newID := mustGen(t)
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	link := filepath.Join(dir, "recovery.txt")
+	original := []byte("outside target")
+	if err := os.WriteFile(target, original, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	if err := writeRotationRecoveryKeysFile(link, oldID, newID); err == nil {
+		t.Fatal("expected symlink recovery path to fail")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read symlink target: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("symlink target was modified: got %q", got)
 	}
 }
 

--- a/cmd/key_test.go
+++ b/cmd/key_test.go
@@ -122,6 +122,67 @@ func TestRotateKeyCore_StoreFailureSkipsRotate(t *testing.T) {
 	}
 }
 
+// TestRotateKeyCore_RotationFailureRestoresOldKey guards the failure mode
+// introduced by fail-fast rotation preflight: if the new key was persisted but
+// rotation then fails before rewriting objects, key storage must be put back to
+// the old key so existing objects remain decryptable.
+func TestRotateKeyCore_RotationFailureRestoresOldKey(t *testing.T) {
+	tr := &rotateTrace{}
+	oldID := mustGen(t)
+	newID := mustGen(t)
+	rotateErr := errors.New("missing object")
+	var stored []*age.X25519Identity
+
+	deps := keyRotateDeps{
+		loadKey: func() (*age.X25519Identity, error) {
+			tr.record("loadKey")
+			return oldID, nil
+		},
+		genKey: func() (*age.X25519Identity, error) {
+			tr.record("genKey")
+			return newID, nil
+		},
+		storeKey: func(id *age.X25519Identity) error {
+			tr.record("storeKey:" + id.Recipient().String())
+			stored = append(stored, id)
+			return nil
+		},
+		rotate: func(*age.X25519Identity, *age.X25519Recipient) (int, error) {
+			tr.record("rotate")
+			return 0, rotateErr
+		},
+	}
+
+	_, _, _, err := rotateKeyCore(deps)
+	if err == nil {
+		t.Fatal("expected rotation error")
+	}
+	if !errors.Is(err, rotateErr) {
+		t.Fatalf("error chain missing rotateErr: %v", err)
+	}
+	if len(stored) != 2 {
+		t.Fatalf("stored %d keys, want new then old", len(stored))
+	}
+	if stored[0] != newID || stored[1] != oldID {
+		t.Fatalf("store order = %v, want new identity then old identity", stored)
+	}
+	want := []string{
+		"loadKey",
+		"genKey",
+		"storeKey:" + newID.Recipient().String(),
+		"rotate",
+		"storeKey:" + oldID.Recipient().String(),
+	}
+	if len(tr.calls) != len(want) {
+		t.Fatalf("call sequence = %v, want %v", tr.calls, want)
+	}
+	for i, c := range want {
+		if tr.calls[i] != c {
+			t.Fatalf("call[%d] = %q, want %q (full: %v)", i, tr.calls[i], c, tr.calls)
+		}
+	}
+}
+
 // TestRotateKeyCore_LoadFailureSkipsEverything is a sanity guard: if loadKey
 // fails there is nothing to rotate and no new key to persist.
 func TestRotateKeyCore_LoadFailureSkipsEverything(t *testing.T) {

--- a/cmd/key_test.go
+++ b/cmd/key_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"filippo.io/age"
@@ -232,6 +233,75 @@ func TestRotateKeyCore_RotationFailureKeepsNewKeyWhenStoreMayHaveChanged(t *test
 		"genKey",
 		"storeKey:" + newID.Recipient().String(),
 		"rotate",
+	}
+	if len(tr.calls) != len(want) {
+		t.Fatalf("call sequence = %v, want %v", tr.calls, want)
+	}
+	for i, c := range want {
+		if tr.calls[i] != c {
+			t.Fatalf("call[%d] = %q, want %q (full: %v)", i, tr.calls[i], c, tr.calls)
+		}
+	}
+}
+
+func TestRotateKeyCore_AmbiguousRotationPreservesRecoveryKeys(t *testing.T) {
+	tr := &rotateTrace{}
+	oldID := mustGen(t)
+	newID := mustGen(t)
+	rotateErr := errors.New("new-key recovery failed")
+	var stored []*age.X25519Identity
+	var preservedOld, preservedNew *age.X25519Identity
+
+	deps := keyRotateDeps{
+		loadKey: func() (*age.X25519Identity, error) {
+			tr.record("loadKey")
+			return oldID, nil
+		},
+		genKey: func() (*age.X25519Identity, error) {
+			tr.record("genKey")
+			return newID, nil
+		},
+		storeKey: func(id *age.X25519Identity) error {
+			tr.record("storeKey:" + id.Recipient().String())
+			stored = append(stored, id)
+			return nil
+		},
+		rotate: func(*age.X25519Identity, *age.X25519Recipient) (int, error) {
+			tr.record("rotate")
+			return 1, errors.Join(store.ErrRotationStoreAmbiguous, rotateErr)
+		},
+		preserveRecoveryKeys: func(old, new *age.X25519Identity) (string, error) {
+			tr.record("preserveRecoveryKeys")
+			preservedOld, preservedNew = old, new
+			return "/tmp/recovery.txt", nil
+		},
+	}
+
+	_, _, _, err := rotateKeyCore(deps)
+	if err == nil {
+		t.Fatal("expected ambiguous rotation error")
+	}
+	if !errors.Is(err, store.ErrRotationStoreAmbiguous) {
+		t.Fatalf("error chain missing ErrRotationStoreAmbiguous: %v", err)
+	}
+	if !errors.Is(err, rotateErr) {
+		t.Fatalf("error chain missing rotateErr: %v", err)
+	}
+	if !strings.Contains(err.Error(), "/tmp/recovery.txt") {
+		t.Fatalf("error should name recovery path: %v", err)
+	}
+	if len(stored) != 1 || stored[0] != newID {
+		t.Fatalf("stored = %v, want only new identity", stored)
+	}
+	if preservedOld != oldID || preservedNew != newID {
+		t.Fatalf("preserved keys = old %v new %v, want original old/new", preservedOld, preservedNew)
+	}
+	want := []string{
+		"loadKey",
+		"genKey",
+		"storeKey:" + newID.Recipient().String(),
+		"rotate",
+		"preserveRecoveryKeys",
 	}
 	if len(tr.calls) != len(want) {
 		t.Fatalf("call sequence = %v, want %v", tr.calls, want)

--- a/cmd/key_test.go
+++ b/cmd/key_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"filippo.io/age"
+	"github.com/coredipper/enclaude/internal/store"
 )
 
 // trace records the order of side-effects so tests can assert that storeKey
@@ -149,13 +150,16 @@ func TestRotateKeyCore_RotationFailureRestoresOldKey(t *testing.T) {
 		},
 		rotate: func(*age.X25519Identity, *age.X25519Recipient) (int, error) {
 			tr.record("rotate")
-			return 0, rotateErr
+			return 0, errors.Join(store.ErrRotationStoreUnchanged, rotateErr)
 		},
 	}
 
 	_, _, _, err := rotateKeyCore(deps)
 	if err == nil {
 		t.Fatal("expected rotation error")
+	}
+	if !errors.Is(err, store.ErrRotationStoreUnchanged) {
+		t.Fatalf("error chain missing ErrRotationStoreUnchanged: %v", err)
 	}
 	if !errors.Is(err, rotateErr) {
 		t.Fatalf("error chain missing rotateErr: %v", err)
@@ -172,6 +176,62 @@ func TestRotateKeyCore_RotationFailureRestoresOldKey(t *testing.T) {
 		"storeKey:" + newID.Recipient().String(),
 		"rotate",
 		"storeKey:" + oldID.Recipient().String(),
+	}
+	if len(tr.calls) != len(want) {
+		t.Fatalf("call sequence = %v, want %v", tr.calls, want)
+	}
+	for i, c := range want {
+		if tr.calls[i] != c {
+			t.Fatalf("call[%d] = %q, want %q (full: %v)", i, tr.calls[i], c, tr.calls)
+		}
+	}
+}
+
+// TestRotateKeyCore_RotationFailureKeepsNewKeyWhenStoreMayHaveChanged
+// verifies late or ambiguous rotation errors do not restore the old key. If
+// object writes may have survived, the newly persisted key is the safer state.
+func TestRotateKeyCore_RotationFailureKeepsNewKeyWhenStoreMayHaveChanged(t *testing.T) {
+	tr := &rotateTrace{}
+	oldID := mustGen(t)
+	newID := mustGen(t)
+	rotateErr := errors.New("saving manifest")
+	var stored []*age.X25519Identity
+
+	deps := keyRotateDeps{
+		loadKey: func() (*age.X25519Identity, error) {
+			tr.record("loadKey")
+			return oldID, nil
+		},
+		genKey: func() (*age.X25519Identity, error) {
+			tr.record("genKey")
+			return newID, nil
+		},
+		storeKey: func(id *age.X25519Identity) error {
+			tr.record("storeKey:" + id.Recipient().String())
+			stored = append(stored, id)
+			return nil
+		},
+		rotate: func(*age.X25519Identity, *age.X25519Recipient) (int, error) {
+			tr.record("rotate")
+			return 2, rotateErr
+		},
+	}
+
+	_, _, _, err := rotateKeyCore(deps)
+	if err == nil {
+		t.Fatal("expected rotation error")
+	}
+	if !errors.Is(err, rotateErr) {
+		t.Fatalf("error chain missing rotateErr: %v", err)
+	}
+	if len(stored) != 1 || stored[0] != newID {
+		t.Fatalf("stored = %v, want only new identity", stored)
+	}
+	want := []string{
+		"loadKey",
+		"genKey",
+		"storeKey:" + newID.Recipient().String(),
+		"rotate",
 	}
 	if len(tr.calls) != len(want) {
 		t.Fatalf("call sequence = %v, want %v", tr.calls, want)

--- a/cmd/purge_plaintext.go
+++ b/cmd/purge_plaintext.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/coredipper/enclaude/internal/config"
+	"github.com/coredipper/enclaude/internal/session"
+	"github.com/coredipper/enclaude/internal/store"
+	"github.com/spf13/cobra"
+)
+
+var (
+	purgeAllManaged bool
+	purgeShred      bool
+	purgeForce      bool
+)
+
+var purgePlaintextCmd = &cobra.Command{
+	Use:   "purge-plaintext",
+	Short: "Remove sealed plaintext files from ~/.claude/",
+	Long: `Remove plaintext files from the Claude directory after they have been
+sealed into the encrypted store. By default this removes only completed
+top-level session JSONL files. Use --all-managed to remove every managed file
+whose on-disk bytes still match the sealed manifest entry.`,
+	RunE: runPurgePlaintext,
+}
+
+func init() {
+	purgePlaintextCmd.Flags().BoolVar(&purgeAllManaged, "all-managed", false, "purge every managed file, not just completed session JSONLs")
+	purgePlaintextCmd.Flags().BoolVar(&purgeShred, "shred", false, "overwrite plaintext before removing it")
+	purgePlaintextCmd.Flags().BoolVar(&purgeForce, "force", false, "purge even if an active Claude session is detected")
+	rootCmd.AddCommand(purgePlaintextCmd)
+}
+
+func runPurgePlaintext(cmd *cobra.Command, args []string) error {
+	sealDir := getSealDir()
+
+	cfg, err := config.Load(sealDir)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+	cfg.Seal.ClaudeDir = getClaudeDir()
+
+	if purgeAllManaged && !purgeForce && !flagYes && !flagDryRun {
+		return fmt.Errorf("refusing --all-managed without --yes or --force")
+	}
+	if session.HasActiveSessions(cfg.Seal.ClaudeDir) && !purgeForce && !flagDryRun {
+		return fmt.Errorf("active Claude Code session detected; refusing to purge plaintext while Claude may be writing (use --force to override)")
+	}
+
+	scope := store.PurgeCompletedSessions
+	if purgeAllManaged {
+		scope = store.PurgeAllManaged
+	}
+
+	if flagDryRun {
+		fmt.Println("(dry run — showing plaintext files that would be purged)")
+	}
+	stats, err := store.PurgePlaintext(cfg, scope, purgeShred, flagDryRun, flagVerbose)
+	if err != nil {
+		return fmt.Errorf("purging plaintext: %w", err)
+	}
+	fmt.Println(stats.Multiline("  ", flagDryRun))
+	if stats.Errors > 0 {
+		return fmt.Errorf("purge had %d errors", stats.Errors)
+	}
+	return nil
+}

--- a/cmd/purge_plaintext.go
+++ b/cmd/purge_plaintext.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/coredipper/enclaude/internal/config"
+	"github.com/coredipper/enclaude/internal/crypto"
 	"github.com/coredipper/enclaude/internal/session"
 	"github.com/coredipper/enclaude/internal/store"
 	"github.com/spf13/cobra"
@@ -21,7 +22,7 @@ var purgePlaintextCmd = &cobra.Command{
 	Long: `Remove plaintext files from the Claude directory after they have been
 sealed into the encrypted store. By default this removes only completed
 top-level session JSONL files. Use --all-managed to remove every managed file
-whose on-disk bytes still match the sealed manifest entry.`,
+whose on-disk bytes still match a recoverable encrypted object.`,
 	RunE: runPurgePlaintext,
 }
 
@@ -53,10 +54,18 @@ func runPurgePlaintext(cmd *cobra.Command, args []string) error {
 		scope = store.PurgeAllManaged
 	}
 
+	identity, source, err := crypto.LoadKey()
+	if err != nil {
+		return fmt.Errorf("loading key: %w", err)
+	}
+	if flagVerbose {
+		fmt.Printf("Using key from %s\n", source)
+	}
+
 	if flagDryRun {
 		fmt.Println("(dry run — showing plaintext files that would be purged)")
 	}
-	stats, err := store.PurgePlaintext(cfg, scope, purgeShred, flagDryRun, flagVerbose)
+	stats, err := store.PurgePlaintext(cfg, identity, scope, purgeShred, flagDryRun, flagVerbose)
 	if err != nil {
 		return fmt.Errorf("purging plaintext: %w", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,8 +25,9 @@ var rootCmd = &cobra.Command{
 	Use:   "enclaude",
 	Short: "Encrypted git-like sync for ~/.claude/",
 	Long: `enclaude provides age-encrypted, git-backed, JSONL-aware sync
-for your Claude Code session data. It encrypts your conversation history,
-settings, and memory at rest and syncs them across devices with version history.`,
+for your Claude Code session data. It stores encrypted copies of your
+conversation history, settings, and memory in a git-backed seal store and syncs
+them across devices with version history.`,
 	Version: Version,
 }
 

--- a/internal/store/repair_test.go
+++ b/internal/store/repair_test.go
@@ -276,6 +276,67 @@ func TestRotateReEncrypts(t *testing.T) {
 	}
 }
 
+// TestRotateMissingObjectFailsWithoutPartialOverwrite guards rotation's
+// all-or-nothing preflight: if any referenced object is missing, no already
+// readable object should be overwritten to the new key.
+func TestRotateMissingObjectFailsWithoutPartialOverwrite(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	oldIdentity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+	if _, err := Seal(cfg, oldIdentity.Recipient(), false, nil); err != nil {
+		t.Fatalf("Seal() error: %v", err)
+	}
+
+	manifest, _ := LoadManifest(sealDir)
+	store := NewObjectStore(sealDir)
+	var keepHash, missingHash string
+	for _, entry := range manifest.Files {
+		if keepHash == "" {
+			keepHash = entry.ContentHash
+			continue
+		}
+		if entry.ContentHash != keepHash {
+			missingHash = entry.ContentHash
+			break
+		}
+	}
+	if keepHash == "" || missingHash == "" {
+		t.Fatal("test needs at least two unique objects")
+	}
+	keepBefore, err := store.Read(keepHash)
+	if err != nil {
+		t.Fatalf("reading keep object: %v", err)
+	}
+	if err := os.Remove(store.ObjectPath(missingHash)); err != nil {
+		t.Fatalf("removing missing object: %v", err)
+	}
+
+	newIdentity, _ := crypto.GenerateKey()
+	rotated, err := Rotate(cfg, oldIdentity, newIdentity.Recipient(), false, nil)
+	if err == nil {
+		t.Fatal("expected Rotate() to fail when an object is missing")
+	}
+	if rotated != 0 {
+		t.Fatalf("rotated = %d, want 0 before preflight failure", rotated)
+	}
+
+	keepAfter, err := store.Read(keepHash)
+	if err != nil {
+		t.Fatalf("reading keep object after failed rotate: %v", err)
+	}
+	if !bytes.Equal(keepAfter, keepBefore) {
+		t.Fatal("failed rotation overwrote an object before preflight completed")
+	}
+	if _, err := crypto.Decrypt(keepAfter, oldIdentity); err != nil {
+		t.Fatalf("old key should still decrypt untouched object: %v", err)
+	}
+	if _, err := crypto.Decrypt(keepAfter, newIdentity); err == nil {
+		t.Fatal("new key should not decrypt object after failed rotation")
+	}
+}
+
 // TestVerifyNoManifest verifies Verify fails with "no manifest found" when
 // the seal store has no manifest yet.
 func TestVerifyNoManifest(t *testing.T) {

--- a/internal/store/repair_test.go
+++ b/internal/store/repair_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -337,6 +338,64 @@ func TestRotateMissingObjectFailsWithoutPartialOverwrite(t *testing.T) {
 	}
 	if _, err := crypto.Decrypt(keepAfter, newIdentity); err == nil {
 		t.Fatal("new key should not decrypt object after failed rotation")
+	}
+}
+
+func TestRotateRollbackFailureRollsForwardToNewKey(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	oldIdentity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+	if _, err := Seal(cfg, oldIdentity.Recipient(), false, nil); err != nil {
+		t.Fatalf("Seal() error: %v", err)
+	}
+
+	manifest, _ := LoadManifest(sealDir)
+	hashes := uniqueManifestHashes(manifest)
+	if len(hashes) < 2 {
+		t.Fatal("test needs at least two unique objects")
+	}
+
+	originalWrite := rotateObjectWrite
+	writeCalls := 0
+	rotateObjectWrite = func(store *ObjectStore, hash string, data []byte) error {
+		writeCalls++
+		switch writeCalls {
+		case 2:
+			return errors.New("apply failed")
+		case 4:
+			return errors.New("rollback failed")
+		default:
+			return originalWrite(store, hash, data)
+		}
+	}
+	t.Cleanup(func() { rotateObjectWrite = originalWrite })
+
+	newIdentity, _ := crypto.GenerateKey()
+	rotated, err := Rotate(cfg, oldIdentity, newIdentity.Recipient(), false, nil)
+	if err == nil {
+		t.Fatal("expected Rotate() to report the apply failure")
+	}
+	if IsRotationStoreUnchanged(err) {
+		t.Fatalf("rollback failure recovered to new-key state, but error was marked old-key-safe: %v", err)
+	}
+	if rotated != 1 {
+		t.Fatalf("rotated = %d, want 1 applied object before injected failure", rotated)
+	}
+
+	store := NewObjectStore(sealDir)
+	for _, hash := range hashes {
+		encrypted, err := store.Read(hash)
+		if err != nil {
+			t.Fatalf("reading object %s: %v", shortHash(hash), err)
+		}
+		if _, err := crypto.Decrypt(encrypted, newIdentity); err != nil {
+			t.Fatalf("new key should decrypt %s after roll-forward recovery: %v", shortHash(hash), err)
+		}
+		if _, err := crypto.Decrypt(encrypted, oldIdentity); err == nil {
+			t.Fatalf("old key should not decrypt %s after roll-forward recovery", shortHash(hash))
+		}
 	}
 }
 

--- a/internal/store/repair_test.go
+++ b/internal/store/repair_test.go
@@ -341,6 +341,9 @@ func TestRotateMissingObjectFailsWithoutPartialOverwrite(t *testing.T) {
 	}
 }
 
+// TestRotateRollbackFailureRollsForwardToNewKey verifies that when applying a
+// rotated object fails and the rollback also fails, Rotate rolls every object
+// forward to the new key and reports an error that is not marked old-key-safe.
 func TestRotateRollbackFailureRollsForwardToNewKey(t *testing.T) {
 	claudeDir := setupTestDir(t)
 	sealDir := t.TempDir()
@@ -399,6 +402,9 @@ func TestRotateRollbackFailureRollsForwardToNewKey(t *testing.T) {
 	}
 }
 
+// TestRotateRollbackAndRollForwardFailureIsAmbiguous verifies that when apply,
+// rollback, and roll-forward all fail, Rotate marks the object-store state
+// ambiguous so the caller preserves both keys instead of guessing.
 func TestRotateRollbackAndRollForwardFailureIsAmbiguous(t *testing.T) {
 	claudeDir := setupTestDir(t)
 	sealDir := t.TempDir()

--- a/internal/store/repair_test.go
+++ b/internal/store/repair_test.go
@@ -318,6 +318,9 @@ func TestRotateMissingObjectFailsWithoutPartialOverwrite(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected Rotate() to fail when an object is missing")
 	}
+	if !IsRotationStoreUnchanged(err) {
+		t.Fatalf("missing-object rotate error should be old-key-safe: %v", err)
+	}
 	if rotated != 0 {
 		t.Fatalf("rotated = %d, want 0 before preflight failure", rotated)
 	}

--- a/internal/store/repair_test.go
+++ b/internal/store/repair_test.go
@@ -399,6 +399,52 @@ func TestRotateRollbackFailureRollsForwardToNewKey(t *testing.T) {
 	}
 }
 
+func TestRotateRollbackAndRollForwardFailureIsAmbiguous(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	oldIdentity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+	if _, err := Seal(cfg, oldIdentity.Recipient(), false, nil); err != nil {
+		t.Fatalf("Seal() error: %v", err)
+	}
+
+	manifest, _ := LoadManifest(sealDir)
+	hashes := uniqueManifestHashes(manifest)
+	if len(hashes) < 2 {
+		t.Fatal("test needs at least two unique objects")
+	}
+
+	originalWrite := rotateObjectWrite
+	writeCalls := 0
+	rotateObjectWrite = func(store *ObjectStore, hash string, data []byte) error {
+		writeCalls++
+		switch writeCalls {
+		case 2:
+			return errors.New("apply failed")
+		case 4:
+			return errors.New("rollback failed")
+		case 5:
+			return errors.New("roll-forward failed")
+		default:
+			return originalWrite(store, hash, data)
+		}
+	}
+	t.Cleanup(func() { rotateObjectWrite = originalWrite })
+
+	newIdentity, _ := crypto.GenerateKey()
+	_, err := Rotate(cfg, oldIdentity, newIdentity.Recipient(), false, nil)
+	if err == nil {
+		t.Fatal("expected Rotate() to report the apply failure")
+	}
+	if !IsRotationStoreAmbiguous(err) {
+		t.Fatalf("error should mark ambiguous key state after failed rollback and roll-forward: %v", err)
+	}
+	if IsRotationStoreUnchanged(err) {
+		t.Fatalf("ambiguous error must not be marked old-key-safe: %v", err)
+	}
+}
+
 // TestVerifyNoManifest verifies Verify fails with "no manifest found" when
 // the seal store has no manifest yet.
 func TestVerifyNoManifest(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -808,8 +808,15 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 		}
 
 		absPath := filepath.Join(cfg.Seal.ClaudeDir, relPath)
-		info, err := os.Lstat(absPath)
+		info, err := lstatNoSymlinkComponents(cfg.Seal.ClaudeDir, relPath)
 		if err != nil {
+			if errors.Is(err, errPathHasSymlink) {
+				stats.Skipped++
+				if verbose {
+					fmt.Fprintf(os.Stderr, "  warning: skipping symlinked path %s\n", relPath)
+				}
+				continue
+			}
 			if os.IsNotExist(err) {
 				stats.Missing++
 				continue
@@ -817,13 +824,6 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 			stats.Errors++
 			if verbose {
 				fmt.Fprintf(os.Stderr, "  warning: cannot stat %s: %v\n", relPath, err)
-			}
-			continue
-		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			stats.Skipped++
-			if verbose {
-				fmt.Fprintf(os.Stderr, "  warning: skipping symlink %s\n", relPath)
 			}
 			continue
 		}
@@ -887,6 +887,36 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 	}
 
 	return stats, nil
+}
+
+var errPathHasSymlink = errors.New("path contains symlink")
+
+func lstatNoSymlinkComponents(root, relPath string) (os.FileInfo, error) {
+	clean := filepath.Clean(relPath)
+	if clean == "." {
+		return nil, fmt.Errorf("empty path")
+	}
+
+	current := root
+	var info os.FileInfo
+	for _, part := range strings.Split(clean, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		var err error
+		info, err = os.Lstat(current)
+		if err != nil {
+			return nil, err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, errPathHasSymlink
+		}
+	}
+	if info == nil {
+		return nil, fmt.Errorf("empty path")
+	}
+	return info, nil
 }
 
 func verifySealedObject(store *ObjectStore, identity age.Identity, entry FileEntry) error {
@@ -1220,17 +1250,17 @@ func Rotate(cfg *config.Config, oldIdentity age.Identity, newRecipient age.Recip
 
 	manifest, err := LoadManifest(sealDir)
 	if err != nil {
-		return 0, fmt.Errorf("loading manifest: %w", err)
+		return 0, rotationStoreUnchangedError(fmt.Errorf("loading manifest: %w", err))
 	}
 	if manifest == nil {
-		return 0, noManifestErr(sealDir)
+		return 0, rotationStoreUnchangedError(noManifestErr(sealDir))
 	}
 
 	hashes := uniqueManifestHashes(manifest)
 	total := len(hashes)
 	tmpDir, err := os.MkdirTemp(sealDir, ".rotate-*")
 	if err != nil {
-		return 0, fmt.Errorf("creating rotation staging dir: %w", err)
+		return 0, rotationStoreUnchangedError(fmt.Errorf("creating rotation staging dir: %w", err))
 	}
 	defer os.RemoveAll(tmpDir)
 	newRoot := filepath.Join(tmpDir, "new")
@@ -1244,24 +1274,24 @@ func Rotate(cfg *config.Config, oldIdentity age.Identity, newRecipient age.Recip
 
 		encrypted, err := store.Read(hash)
 		if err != nil {
-			return 0, fmt.Errorf("reading object %s: %w", shortHash(hash), err)
+			return 0, rotationStoreUnchangedError(fmt.Errorf("reading object %s: %w", shortHash(hash), err))
 		}
 
 		plaintext, err := crypto.Decrypt(encrypted, oldIdentity)
 		if err != nil {
-			return 0, fmt.Errorf("decrypting object %s: %w", shortHash(hash), err)
+			return 0, rotationStoreUnchangedError(fmt.Errorf("decrypting object %s: %w", shortHash(hash), err))
 		}
 
 		newEncrypted, err := crypto.Encrypt(plaintext, newRecipient)
 		if err != nil {
-			return 0, fmt.Errorf("re-encrypting object %s: %w", shortHash(hash), err)
+			return 0, rotationStoreUnchangedError(fmt.Errorf("re-encrypting object %s: %w", shortHash(hash), err))
 		}
 
 		if err := writeStagedObject(newRoot, hash, newEncrypted); err != nil {
-			return 0, fmt.Errorf("staging rotated object %s: %w", shortHash(hash), err)
+			return 0, rotationStoreUnchangedError(fmt.Errorf("staging rotated object %s: %w", shortHash(hash), err))
 		}
 		if err := writeStagedObject(oldRoot, hash, encrypted); err != nil {
-			return 0, fmt.Errorf("staging rollback object %s: %w", shortHash(hash), err)
+			return 0, rotationStoreUnchangedError(fmt.Errorf("staging rollback object %s: %w", shortHash(hash), err))
 		}
 	}
 
@@ -1269,17 +1299,24 @@ func Rotate(cfg *config.Config, oldIdentity age.Identity, newRecipient age.Recip
 	for _, hash := range hashes {
 		data, err := os.ReadFile(stagedObjectPath(newRoot, hash))
 		if err != nil {
-			return len(applied), fmt.Errorf("reading staged object %s: %w", shortHash(hash), err)
+			rollbackErr := rollbackRotatedObjects(store, oldRoot, applied)
+			if rollbackErr != nil {
+				return len(applied), errors.Join(
+					fmt.Errorf("reading staged object %s: %w", shortHash(hash), err),
+					fmt.Errorf("rollback failed: %w", rollbackErr),
+				)
+			}
+			return len(applied), rotationStoreUnchangedError(fmt.Errorf("reading staged object %s: %w", shortHash(hash), err))
 		}
 		if err := store.Write(hash, data); err != nil {
-			rollbackErr := rollbackRotatedObjects(store, oldRoot, applied)
+			rollbackErr := rollbackRotatedObjects(store, oldRoot, append(applied, hash))
 			if rollbackErr != nil {
 				return len(applied), errors.Join(
 					fmt.Errorf("applying rotated object %s: %w", shortHash(hash), err),
 					fmt.Errorf("rollback failed: %w", rollbackErr),
 				)
 			}
-			return len(applied), fmt.Errorf("applying rotated object %s: %w", shortHash(hash), err)
+			return len(applied), rotationStoreUnchangedError(fmt.Errorf("applying rotated object %s: %w", shortHash(hash), err))
 		}
 		applied = append(applied, hash)
 		if verbose {
@@ -1293,6 +1330,21 @@ func Rotate(cfg *config.Config, oldIdentity age.Identity, newRecipient age.Recip
 	}
 
 	return len(applied), nil
+}
+
+// ErrRotationStoreUnchanged marks a rotation failure whose object writes either
+// never started or were fully rolled back. When callers already persisted a new
+// key before Rotate, this error means the old key should be restored.
+var ErrRotationStoreUnchanged = errors.New("rotation left object store encrypted with old key")
+
+// IsRotationStoreUnchanged reports whether a rotation error left the object
+// store decryptable with the old key.
+func IsRotationStoreUnchanged(err error) bool {
+	return errors.Is(err, ErrRotationStoreUnchanged)
+}
+
+func rotationStoreUnchangedError(err error) error {
+	return fmt.Errorf("%w: %w", ErrRotationStoreUnchanged, err)
 }
 
 func uniqueManifestHashes(manifest *Manifest) []string {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	cryptorand "crypto/rand"
 	"errors"
 	"fmt"
 	"maps"
@@ -786,6 +787,12 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 
 	activeSessions := activeSessionIDs(cfg.Seal.ClaudeDir)
 	objects := NewObjectStore(cfg.Seal.SealDir)
+	root, err := os.OpenRoot(cfg.Seal.ClaudeDir)
+	if err != nil {
+		return stats, fmt.Errorf("opening Claude root: %w", err)
+	}
+	defer root.Close()
+
 	paths := make([]string, 0, len(manifest.Files))
 	for path := range manifest.Files {
 		paths = append(paths, path)
@@ -807,8 +814,7 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 			continue
 		}
 
-		absPath := filepath.Join(cfg.Seal.ClaudeDir, relPath)
-		info, err := lstatNoSymlinkComponents(cfg.Seal.ClaudeDir, relPath)
+		info, err := lstatNoSymlinkComponents(root, relPath)
 		if err != nil {
 			if errors.Is(err, errPathHasSymlink) {
 				stats.Skipped++
@@ -832,7 +838,8 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 			continue
 		}
 
-		plaintext, err := os.ReadFile(absPath)
+		purgeAfterPathCheck(relPath)
+		plaintext, err := root.ReadFile(relPath)
 		if err != nil {
 			stats.Errors++
 			if verbose {
@@ -865,9 +872,9 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 		}
 
 		if shred {
-			err = crypto.ShredFile(absPath)
+			err = shredRootedFile(root, relPath, info.Size())
 		} else {
-			err = os.Remove(absPath)
+			err = root.Remove(relPath)
 		}
 		if err != nil {
 			stats.Errors++
@@ -880,9 +887,9 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 		if verbose {
 			fmt.Printf("  [purge] %s (%s)\n", relPath, FormatSize(int64(len(plaintext))))
 		}
-		dir := filepath.Dir(absPath)
-		if dir != cfg.Seal.ClaudeDir {
-			_ = os.Remove(dir)
+		dir := filepath.Dir(relPath)
+		if dir != "." {
+			_ = root.Remove(dir)
 		}
 	}
 
@@ -891,13 +898,16 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 
 var errPathHasSymlink = errors.New("path contains symlink")
 
-func lstatNoSymlinkComponents(root, relPath string) (os.FileInfo, error) {
+// purgeAfterPathCheck is a test hook for exercising path-swap races.
+var purgeAfterPathCheck = func(string) {}
+
+func lstatNoSymlinkComponents(root *os.Root, relPath string) (os.FileInfo, error) {
 	clean := filepath.Clean(relPath)
 	if clean == "." {
 		return nil, fmt.Errorf("empty path")
 	}
 
-	current := root
+	current := ""
 	var info os.FileInfo
 	for _, part := range strings.Split(clean, string(os.PathSeparator)) {
 		if part == "" || part == "." {
@@ -905,7 +915,7 @@ func lstatNoSymlinkComponents(root, relPath string) (os.FileInfo, error) {
 		}
 		current = filepath.Join(current, part)
 		var err error
-		info, err = os.Lstat(current)
+		info, err = root.Lstat(current)
 		if err != nil {
 			return nil, err
 		}
@@ -917,6 +927,39 @@ func lstatNoSymlinkComponents(root, relPath string) (os.FileInfo, error) {
 		return nil, fmt.Errorf("empty path")
 	}
 	return info, nil
+}
+
+func shredRootedFile(root *os.Root, relPath string, size int64) error {
+	f, err := root.OpenFile(relPath, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("opening %s for overwrite: %w", relPath, err)
+	}
+
+	buf := make([]byte, min(size, 64*1024))
+	for written := int64(0); written < size; {
+		chunk := int(min(int64(len(buf)), size-written))
+		if _, err := cryptorand.Read(buf[:chunk]); err != nil {
+			f.Close()
+			return fmt.Errorf("generating overwrite bytes for %s: %w", relPath, err)
+		}
+		if _, err := f.Write(buf[:chunk]); err != nil {
+			f.Close()
+			return fmt.Errorf("overwriting %s: %w", relPath, err)
+		}
+		written += int64(chunk)
+	}
+
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return fmt.Errorf("syncing %s: %w", relPath, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("closing %s: %w", relPath, err)
+	}
+	if err := root.Remove(relPath); err != nil {
+		return fmt.Errorf("removing %s: %w", relPath, err)
+	}
+	return nil
 }
 
 func verifySealedObject(store *ObjectStore, identity age.Identity, entry FileEntry) error {
@@ -1299,24 +1342,17 @@ func Rotate(cfg *config.Config, oldIdentity age.Identity, newRecipient age.Recip
 	for _, hash := range hashes {
 		data, err := os.ReadFile(stagedObjectPath(newRoot, hash))
 		if err != nil {
-			rollbackErr := rollbackRotatedObjects(store, oldRoot, applied)
-			if rollbackErr != nil {
-				return len(applied), errors.Join(
-					fmt.Errorf("reading staged object %s: %w", shortHash(hash), err),
-					fmt.Errorf("rollback failed: %w", rollbackErr),
-				)
-			}
-			return len(applied), rotationStoreUnchangedError(fmt.Errorf("reading staged object %s: %w", shortHash(hash), err))
+			return len(applied), recoverRotationApplyFailure(
+				store, oldRoot, newRoot, hashes, applied,
+				fmt.Errorf("reading staged object %s: %w", shortHash(hash), err),
+			)
 		}
-		if err := store.Write(hash, data); err != nil {
-			rollbackErr := rollbackRotatedObjects(store, oldRoot, append(applied, hash))
-			if rollbackErr != nil {
-				return len(applied), errors.Join(
-					fmt.Errorf("applying rotated object %s: %w", shortHash(hash), err),
-					fmt.Errorf("rollback failed: %w", rollbackErr),
-				)
-			}
-			return len(applied), rotationStoreUnchangedError(fmt.Errorf("applying rotated object %s: %w", shortHash(hash), err))
+		if err := rotateObjectWrite(store, hash, data); err != nil {
+			rollbackHashes := append(append([]string{}, applied...), hash)
+			return len(applied), recoverRotationApplyFailure(
+				store, oldRoot, newRoot, hashes, rollbackHashes,
+				fmt.Errorf("applying rotated object %s: %w", shortHash(hash), err),
+			)
 		}
 		applied = append(applied, hash)
 		if verbose {
@@ -1345,6 +1381,31 @@ func IsRotationStoreUnchanged(err error) bool {
 
 func rotationStoreUnchangedError(err error) error {
 	return fmt.Errorf("%w: %w", ErrRotationStoreUnchanged, err)
+}
+
+// rotateObjectWrite is a test hook for exercising apply/rollback failures.
+var rotateObjectWrite = func(store *ObjectStore, hash string, data []byte) error {
+	return store.Write(hash, data)
+}
+
+func recoverRotationApplyFailure(store *ObjectStore, oldRoot, newRoot string, allHashes, rollbackHashes []string, cause error) error {
+	rollbackErr := rollbackRotatedObjects(store, oldRoot, rollbackHashes)
+	if rollbackErr == nil {
+		return rotationStoreUnchangedError(cause)
+	}
+
+	if forwardErr := rollForwardRotatedObjects(store, newRoot, allHashes); forwardErr != nil {
+		return errors.Join(
+			cause,
+			fmt.Errorf("rollback failed: %w", rollbackErr),
+			fmt.Errorf("new-key recovery failed: %w", forwardErr),
+		)
+	}
+
+	return errors.Join(
+		cause,
+		fmt.Errorf("rollback failed; recovered all rotated objects with new key: %w", rollbackErr),
+	)
 }
 
 func uniqueManifestHashes(manifest *Manifest) []string {
@@ -1382,8 +1443,23 @@ func rollbackRotatedObjects(store *ObjectStore, oldRoot string, hashes []string)
 			errs = append(errs, fmt.Errorf("read backup %s: %w", shortHash(hash), err))
 			continue
 		}
-		if err := store.Write(hash, data); err != nil {
+		if err := rotateObjectWrite(store, hash, data); err != nil {
 			errs = append(errs, fmt.Errorf("restore %s: %w", shortHash(hash), err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func rollForwardRotatedObjects(store *ObjectStore, newRoot string, hashes []string) error {
+	var errs []error
+	for _, hash := range hashes {
+		data, err := os.ReadFile(stagedObjectPath(newRoot, hash))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("read rotated %s: %w", shortHash(hash), err))
+			continue
+		}
+		if err := rotateObjectWrite(store, hash, data); err != nil {
+			errs = append(errs, fmt.Errorf("recover %s: %w", shortHash(hash), err))
 		}
 	}
 	return errors.Join(errs...)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -920,6 +920,9 @@ var purgeAfterPathCheck = func(string) {}
 // purgeBeforeQuarantine is a test hook for exercising final remove races.
 var purgeBeforeQuarantine = func(string) {}
 
+// purgeAfterQuarantine is a test hook for exercising post-quarantine errors.
+var purgeAfterQuarantine = func(string, *os.File) {}
+
 func lstatNoSymlinkComponents(root *os.Root, relPath string) (os.FileInfo, error) {
 	clean := filepath.Clean(relPath)
 	if clean == "." {
@@ -983,6 +986,7 @@ func purgeOpenRootedFile(root *os.Root, relPath string, f *os.File, info os.File
 		_ = f.Close()
 		return err
 	}
+	purgeAfterQuarantine(relPath, f)
 
 	if shred {
 		err = shredOpenFile(f, relPath, info.Size())
@@ -990,6 +994,9 @@ func purgeOpenRootedFile(root *os.Root, relPath string, f *os.File, info os.File
 		err = f.Close()
 	}
 	if err != nil {
+		if cleanupErr := cleanupQuarantinedRootedFile(root, relPath, tombstone, tombDir, info); cleanupErr != nil {
+			return errors.Join(err, cleanupErr)
+		}
 		return err
 	}
 	if err := root.Remove(tombstone); err != nil {
@@ -1033,6 +1040,34 @@ func quarantineRootedSameFile(root *os.Root, relPath string, expected os.FileInf
 		return tombstone, tombDir, nil
 	}
 	return "", "", fmt.Errorf("creating unique purge tombstone")
+}
+
+func cleanupQuarantinedRootedFile(root *os.Root, relPath, tombstone, tombDir string, expected os.FileInfo) error {
+	tombInfo, err := root.Lstat(tombstone)
+	if err != nil {
+		if os.IsNotExist(err) {
+			_ = root.Remove(tombDir)
+			return nil
+		}
+		return fmt.Errorf("checking quarantined %s: %w", relPath, err)
+	}
+	if !tombInfo.Mode().IsRegular() || !os.SameFile(expected, tombInfo) {
+		return errPathChanged
+	}
+
+	if err := root.Link(tombstone, relPath); err == nil {
+		if err := root.Remove(tombstone); err != nil {
+			return fmt.Errorf("removing quarantined %s after restore: %w", relPath, err)
+		}
+		_ = root.Remove(tombDir)
+		return nil
+	}
+
+	if err := root.Remove(tombstone); err != nil {
+		return fmt.Errorf("cleaning quarantined %s: %w", relPath, err)
+	}
+	_ = root.Remove(tombDir)
+	return nil
 }
 
 func randomPurgeSuffix() (string, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -888,7 +888,7 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 			continue
 		}
 
-		err = purgeOpenRootedFile(root, relPath, file, fileInfo, shred)
+		err = purgeOpenRootedFile(root, relPath, file, fileInfo, entry.ContentHash, shred)
 		if err != nil {
 			stats.Errors++
 			if verbose {
@@ -979,7 +979,7 @@ func ensureRootedSameFile(root *os.Root, relPath string, expected os.FileInfo) e
 	return nil
 }
 
-func purgeOpenRootedFile(root *os.Root, relPath string, f *os.File, info os.FileInfo, shred bool) error {
+func purgeOpenRootedFile(root *os.Root, relPath string, f *os.File, info os.FileInfo, expectedHash string, shred bool) error {
 	purgeBeforeQuarantine(relPath)
 	tombstone, tombDir, err := quarantineRootedSameFile(root, relPath, info)
 	if err != nil {
@@ -994,7 +994,7 @@ func purgeOpenRootedFile(root *os.Root, relPath string, f *os.File, info os.File
 		err = f.Close()
 	}
 	if err != nil {
-		if cleanupErr := cleanupQuarantinedRootedFile(root, relPath, tombstone, tombDir, info); cleanupErr != nil {
+		if cleanupErr := cleanupQuarantinedRootedFile(root, relPath, tombstone, tombDir, info, expectedHash); cleanupErr != nil {
 			return errors.Join(err, cleanupErr)
 		}
 		return err
@@ -1042,7 +1042,7 @@ func quarantineRootedSameFile(root *os.Root, relPath string, expected os.FileInf
 	return "", "", fmt.Errorf("creating unique purge tombstone")
 }
 
-func cleanupQuarantinedRootedFile(root *os.Root, relPath, tombstone, tombDir string, expected os.FileInfo) error {
+func cleanupQuarantinedRootedFile(root *os.Root, relPath, tombstone, tombDir string, expected os.FileInfo, expectedHash string) error {
 	tombInfo, err := root.Lstat(tombstone)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -1055,12 +1055,23 @@ func cleanupQuarantinedRootedFile(root *os.Root, relPath, tombstone, tombDir str
 		return errPathChanged
 	}
 
-	if err := root.Link(tombstone, relPath); err == nil {
+	restorable, hashErr := rootedFileMatchesHash(root, tombstone, expected, expectedHash)
+	if hashErr != nil {
 		if err := root.Remove(tombstone); err != nil {
-			return fmt.Errorf("removing quarantined %s after restore: %w", relPath, err)
+			return errors.Join(hashErr, fmt.Errorf("cleaning quarantined %s: %w", relPath, err))
 		}
 		_ = root.Remove(tombDir)
-		return nil
+		return hashErr
+	}
+	if restorable {
+		err := root.Link(tombstone, relPath)
+		if err == nil {
+			if err := root.Remove(tombstone); err != nil {
+				return fmt.Errorf("removing quarantined %s after restore: %w", relPath, err)
+			}
+			_ = root.Remove(tombDir)
+			return nil
+		}
 	}
 
 	if err := root.Remove(tombstone); err != nil {
@@ -1068,6 +1079,25 @@ func cleanupQuarantinedRootedFile(root *os.Root, relPath, tombstone, tombDir str
 	}
 	_ = root.Remove(tombDir)
 	return nil
+}
+
+func rootedFileMatchesHash(root *os.Root, relPath string, expected os.FileInfo, expectedHash string) (bool, error) {
+	if expectedHash == "" {
+		return false, nil
+	}
+	f, _, err := openRootedSameFile(root, relPath, expected, os.O_RDONLY)
+	if err != nil {
+		return false, err
+	}
+	data, err := io.ReadAll(f)
+	closeErr := f.Close()
+	if err != nil {
+		return false, err
+	}
+	if closeErr != nil {
+		return false, closeErr
+	}
+	return ContentHash(data) == expectedHash, nil
 }
 
 func randomPurgeSuffix() (string, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -773,7 +773,7 @@ func (s PurgePlaintextStats) Multiline(indent string, dryRun bool) string {
 
 // PurgePlaintext removes plaintext copies only when the on-disk bytes still
 // match the sealed manifest hash. Unsynced edits are skipped, not deleted.
-func PurgePlaintext(cfg *config.Config, scope PurgeScope, shred, dryRun, verbose bool) (PurgePlaintextStats, error) {
+func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope, shred, dryRun, verbose bool) (PurgePlaintextStats, error) {
 	var stats PurgePlaintextStats
 
 	manifest, err := LoadManifest(cfg.Seal.SealDir)
@@ -785,6 +785,7 @@ func PurgePlaintext(cfg *config.Config, scope PurgeScope, shred, dryRun, verbose
 	}
 
 	activeSessions := activeSessionIDs(cfg.Seal.ClaudeDir)
+	objects := NewObjectStore(cfg.Seal.SealDir)
 	paths := make([]string, 0, len(manifest.Files))
 	for path := range manifest.Files {
 		paths = append(paths, path)
@@ -807,7 +808,7 @@ func PurgePlaintext(cfg *config.Config, scope PurgeScope, shred, dryRun, verbose
 		}
 
 		absPath := filepath.Join(cfg.Seal.ClaudeDir, relPath)
-		info, err := os.Stat(absPath)
+		info, err := os.Lstat(absPath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				stats.Missing++
@@ -819,7 +820,14 @@ func PurgePlaintext(cfg *config.Config, scope PurgeScope, shred, dryRun, verbose
 			}
 			continue
 		}
-		if info.IsDir() {
+		if info.Mode()&os.ModeSymlink != 0 {
+			stats.Skipped++
+			if verbose {
+				fmt.Fprintf(os.Stderr, "  warning: skipping symlink %s\n", relPath)
+			}
+			continue
+		}
+		if !info.Mode().IsRegular() {
 			stats.Skipped++
 			continue
 		}
@@ -836,6 +844,13 @@ func PurgePlaintext(cfg *config.Config, scope PurgeScope, shred, dryRun, verbose
 			stats.Skipped++
 			if verbose {
 				fmt.Fprintf(os.Stderr, "  warning: skipping changed plaintext %s\n", relPath)
+			}
+			continue
+		}
+		if err := verifySealedObject(objects, identity, entry); err != nil {
+			stats.Errors++
+			if verbose {
+				fmt.Fprintf(os.Stderr, "  warning: sealed object for %s is not recoverable: %v\n", relPath, err)
 			}
 			continue
 		}
@@ -872,6 +887,21 @@ func PurgePlaintext(cfg *config.Config, scope PurgeScope, shred, dryRun, verbose
 	}
 
 	return stats, nil
+}
+
+func verifySealedObject(store *ObjectStore, identity age.Identity, entry FileEntry) error {
+	encrypted, err := store.Read(entry.ContentHash)
+	if err != nil {
+		return fmt.Errorf("read object: %w", err)
+	}
+	plaintext, err := crypto.Decrypt(encrypted, identity)
+	if err != nil {
+		return fmt.Errorf("decrypt object: %w", err)
+	}
+	if ContentHash(plaintext) != entry.ContentHash {
+		return fmt.Errorf("hash mismatch")
+	}
+	return nil
 }
 
 func purgeSelects(relPath string, entry FileEntry, scope PurgeScope, active map[string]bool) bool {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,11 +2,13 @@ package store
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -360,6 +362,18 @@ func activeSessionIDs(claudeDir string) map[string]bool {
 // isSessionPath matches the on-disk shape of a Claude session transcript.
 func isSessionPath(relPath string) bool {
 	return strings.HasPrefix(relPath, "projects/") && strings.HasSuffix(relPath, ".jsonl")
+}
+
+// isTopLevelSessionPath narrows isSessionPath to Claude transcript files at
+// projects/<project>/<session>.jsonl. Nested JSONL files, such as subagent
+// logs, are managed data but not purged by the completed-session default.
+func isTopLevelSessionPath(relPath string) bool {
+	_, sub, ok := splitProjectKey(relPath)
+	if !ok || sub == "" || !strings.HasSuffix(sub, ".jsonl") {
+		return false
+	}
+	name := strings.TrimPrefix(sub, "/")
+	return name != "" && !strings.Contains(name, "/")
 }
 
 // unsealFile decrypts a single file and writes it to the claude directory.
@@ -722,6 +736,158 @@ func UnsealStatus(cfg *config.Config, opts ...UnsealOption) (*DiffResult, error)
 	return &result, nil
 }
 
+// PurgeScope controls which sealed plaintext files are removed from claudeDir.
+type PurgeScope int
+
+const (
+	// PurgeCompletedSessions removes only completed top-level session JSONLs.
+	PurgeCompletedSessions PurgeScope = iota
+	// PurgeAllManaged removes every managed file whose on-disk bytes still
+	// match the sealed manifest entry. Callers should gate this carefully.
+	PurgeAllManaged
+)
+
+// PurgePlaintextStats describes a plaintext purge run.
+type PurgePlaintextStats struct {
+	Candidates int
+	Removed    int
+	Missing    int
+	Skipped    int
+	Errors     int
+	Bytes      int64
+}
+
+func (s PurgePlaintextStats) String() string {
+	return fmt.Sprintf("%d candidates: %d removed, %d missing, %d skipped, %d errors",
+		s.Candidates, s.Removed, s.Missing, s.Skipped, s.Errors)
+}
+
+func (s PurgePlaintextStats) Multiline(indent string, dryRun bool) string {
+	action := "removed"
+	if dryRun {
+		action = "would remove"
+	}
+	return fmt.Sprintf("%s%d candidates: %d %s (%s), %d missing, %d skipped, %d errors",
+		indent, s.Candidates, s.Removed, action, FormatSize(s.Bytes), s.Missing, s.Skipped, s.Errors)
+}
+
+// PurgePlaintext removes plaintext copies only when the on-disk bytes still
+// match the sealed manifest hash. Unsynced edits are skipped, not deleted.
+func PurgePlaintext(cfg *config.Config, scope PurgeScope, shred, dryRun, verbose bool) (PurgePlaintextStats, error) {
+	var stats PurgePlaintextStats
+
+	manifest, err := LoadManifest(cfg.Seal.SealDir)
+	if err != nil {
+		return stats, fmt.Errorf("loading manifest: %w", err)
+	}
+	if manifest == nil {
+		return stats, noManifestErr(cfg.Seal.SealDir)
+	}
+
+	activeSessions := activeSessionIDs(cfg.Seal.ClaudeDir)
+	paths := make([]string, 0, len(manifest.Files))
+	for path := range manifest.Files {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	for _, relPath := range paths {
+		entry := manifest.Files[relPath]
+		if !purgeSelects(relPath, entry, scope, activeSessions) {
+			continue
+		}
+		stats.Candidates++
+
+		if !filepath.IsLocal(relPath) {
+			stats.Errors++
+			if verbose {
+				fmt.Fprintf(os.Stderr, "  warning: skipping invalid path %s\n", relPath)
+			}
+			continue
+		}
+
+		absPath := filepath.Join(cfg.Seal.ClaudeDir, relPath)
+		info, err := os.Stat(absPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				stats.Missing++
+				continue
+			}
+			stats.Errors++
+			if verbose {
+				fmt.Fprintf(os.Stderr, "  warning: cannot stat %s: %v\n", relPath, err)
+			}
+			continue
+		}
+		if info.IsDir() {
+			stats.Skipped++
+			continue
+		}
+
+		plaintext, err := os.ReadFile(absPath)
+		if err != nil {
+			stats.Errors++
+			if verbose {
+				fmt.Fprintf(os.Stderr, "  warning: cannot read %s: %v\n", relPath, err)
+			}
+			continue
+		}
+		if ContentHash(plaintext) != entry.ContentHash {
+			stats.Skipped++
+			if verbose {
+				fmt.Fprintf(os.Stderr, "  warning: skipping changed plaintext %s\n", relPath)
+			}
+			continue
+		}
+
+		stats.Bytes += int64(len(plaintext))
+		if dryRun {
+			stats.Removed++
+			if verbose {
+				fmt.Printf("  [purge] %s (%s)\n", relPath, FormatSize(int64(len(plaintext))))
+			}
+			continue
+		}
+
+		if shred {
+			err = crypto.ShredFile(absPath)
+		} else {
+			err = os.Remove(absPath)
+		}
+		if err != nil {
+			stats.Errors++
+			if verbose {
+				fmt.Fprintf(os.Stderr, "  warning: cannot purge %s: %v\n", relPath, err)
+			}
+			continue
+		}
+		stats.Removed++
+		if verbose {
+			fmt.Printf("  [purge] %s (%s)\n", relPath, FormatSize(int64(len(plaintext))))
+		}
+		dir := filepath.Dir(absPath)
+		if dir != cfg.Seal.ClaudeDir {
+			_ = os.Remove(dir)
+		}
+	}
+
+	return stats, nil
+}
+
+func purgeSelects(relPath string, entry FileEntry, scope PurgeScope, active map[string]bool) bool {
+	switch scope {
+	case PurgeCompletedSessions:
+		return isTopLevelSessionPath(relPath) && entry.SessionComplete
+	case PurgeAllManaged:
+		if isSessionPath(relPath) && !isSessionCompleteFor(relPath, active) {
+			return false
+		}
+		return true
+	default:
+		return false
+	}
+}
+
 // ResolveMergeStrategy finds the merge strategy for a file based on glob patterns.
 func ResolveMergeStrategy(relPath string, strategies map[string]string) string {
 	strategy, _ := ResolveMergeStrategyWithPattern(relPath, strategies)
@@ -1030,54 +1196,122 @@ func Rotate(cfg *config.Config, oldIdentity age.Identity, newRecipient age.Recip
 		return 0, noManifestErr(sealDir)
 	}
 
-	total := len(manifest.Files)
-	rotated := 0
-	i := 0
+	hashes := uniqueManifestHashes(manifest)
+	total := len(hashes)
+	tmpDir, err := os.MkdirTemp(sealDir, ".rotate-*")
+	if err != nil {
+		return 0, fmt.Errorf("creating rotation staging dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	newRoot := filepath.Join(tmpDir, "new")
+	oldRoot := filepath.Join(tmpDir, "old")
 
-	for path, entry := range manifest.Files {
+	for i, hash := range hashes {
 		i++
 		if progress != nil {
-			progress(i, total, path)
+			progress(i, total, hash)
 		}
 
-		encrypted, err := store.Read(entry.ContentHash)
+		encrypted, err := store.Read(hash)
 		if err != nil {
-			if verbose {
-				fmt.Fprintf(os.Stderr, "  warning: cannot read %s: %v\n", path, err)
-			}
-			continue
+			return 0, fmt.Errorf("reading object %s: %w", shortHash(hash), err)
 		}
 
 		plaintext, err := crypto.Decrypt(encrypted, oldIdentity)
 		if err != nil {
-			if verbose {
-				fmt.Fprintf(os.Stderr, "  warning: cannot decrypt %s: %v\n", path, err)
-			}
-			continue
+			return 0, fmt.Errorf("decrypting object %s: %w", shortHash(hash), err)
 		}
 
 		newEncrypted, err := crypto.Encrypt(plaintext, newRecipient)
 		if err != nil {
-			if verbose {
-				fmt.Fprintf(os.Stderr, "  warning: cannot re-encrypt %s: %v\n", path, err)
+			return 0, fmt.Errorf("re-encrypting object %s: %w", shortHash(hash), err)
+		}
+
+		if err := writeStagedObject(newRoot, hash, newEncrypted); err != nil {
+			return 0, fmt.Errorf("staging rotated object %s: %w", shortHash(hash), err)
+		}
+		if err := writeStagedObject(oldRoot, hash, encrypted); err != nil {
+			return 0, fmt.Errorf("staging rollback object %s: %w", shortHash(hash), err)
+		}
+	}
+
+	applied := make([]string, 0, len(hashes))
+	for _, hash := range hashes {
+		data, err := os.ReadFile(stagedObjectPath(newRoot, hash))
+		if err != nil {
+			return len(applied), fmt.Errorf("reading staged object %s: %w", shortHash(hash), err)
+		}
+		if err := store.Write(hash, data); err != nil {
+			rollbackErr := rollbackRotatedObjects(store, oldRoot, applied)
+			if rollbackErr != nil {
+				return len(applied), errors.Join(
+					fmt.Errorf("applying rotated object %s: %w", shortHash(hash), err),
+					fmt.Errorf("rollback failed: %w", rollbackErr),
+				)
 			}
-			continue
+			return len(applied), fmt.Errorf("applying rotated object %s: %w", shortHash(hash), err)
 		}
-
-		// Overwrite in place — content hash stays the same
-		if err := store.Write(entry.ContentHash, newEncrypted); err != nil {
-			continue
+		applied = append(applied, hash)
+		if verbose {
+			fmt.Printf("  [rotate] %s\n", shortHash(hash))
 		}
-
-		rotated++
 	}
 
 	// Save manifest (updates SealedAt timestamp)
 	if err := manifest.Save(sealDir); err != nil {
-		return rotated, fmt.Errorf("saving manifest: %w", err)
+		return len(applied), fmt.Errorf("saving manifest: %w", err)
 	}
 
-	return rotated, nil
+	return len(applied), nil
+}
+
+func uniqueManifestHashes(manifest *Manifest) []string {
+	seen := make(map[string]bool, len(manifest.Files))
+	for _, entry := range manifest.Files {
+		if entry.ContentHash != "" {
+			seen[entry.ContentHash] = true
+		}
+	}
+	hashes := make([]string, 0, len(seen))
+	for hash := range seen {
+		hashes = append(hashes, hash)
+	}
+	sort.Strings(hashes)
+	return hashes
+}
+
+func stagedObjectPath(root, hash string) string {
+	return filepath.Join(root, hash[:2], hash[2:]+".age")
+}
+
+func writeStagedObject(root, hash string, data []byte) error {
+	path := stagedObjectPath(root, hash)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+func rollbackRotatedObjects(store *ObjectStore, oldRoot string, hashes []string) error {
+	var errs []error
+	for _, hash := range hashes {
+		data, err := os.ReadFile(stagedObjectPath(oldRoot, hash))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("read backup %s: %w", shortHash(hash), err))
+			continue
+		}
+		if err := store.Write(hash, data); err != nil {
+			errs = append(errs, fmt.Errorf("restore %s: %w", shortHash(hash), err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func shortHash(hash string) string {
+	if len(hash) < 16 {
+		return hash
+	}
+	return hash[:16]
 }
 
 // FormatSize formats a byte count as a human-readable string.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5,6 +5,7 @@ import (
 	cryptorand "crypto/rand"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"path/filepath"
@@ -838,8 +839,12 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 			continue
 		}
 
+		openFlag := os.O_RDONLY
+		if shred {
+			openFlag = os.O_RDWR
+		}
 		purgeAfterPathCheck(relPath)
-		plaintext, err := root.ReadFile(relPath)
+		file, fileInfo, err := openRootedSameFile(root, relPath, info, openFlag)
 		if err != nil {
 			stats.Errors++
 			if verbose {
@@ -847,7 +852,17 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 			}
 			continue
 		}
+		plaintext, err := io.ReadAll(file)
+		if err != nil {
+			_ = file.Close()
+			stats.Errors++
+			if verbose {
+				fmt.Fprintf(os.Stderr, "  warning: cannot read %s: %v\n", relPath, err)
+			}
+			continue
+		}
 		if ContentHash(plaintext) != entry.ContentHash {
+			_ = file.Close()
 			stats.Skipped++
 			if verbose {
 				fmt.Fprintf(os.Stderr, "  warning: skipping changed plaintext %s\n", relPath)
@@ -855,6 +870,7 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 			continue
 		}
 		if err := verifySealedObject(objects, identity, entry); err != nil {
+			_ = file.Close()
 			stats.Errors++
 			if verbose {
 				fmt.Fprintf(os.Stderr, "  warning: sealed object for %s is not recoverable: %v\n", relPath, err)
@@ -864,6 +880,7 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 
 		stats.Bytes += int64(len(plaintext))
 		if dryRun {
+			_ = file.Close()
 			stats.Removed++
 			if verbose {
 				fmt.Printf("  [purge] %s (%s)\n", relPath, FormatSize(int64(len(plaintext))))
@@ -872,8 +889,26 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 		}
 
 		if shred {
-			err = shredRootedFile(root, relPath, info.Size())
+			err = shredOpenFile(file, relPath, fileInfo.Size())
+			if err == nil {
+				err = ensureRootedSameFile(root, relPath, fileInfo)
+			}
+			if err == nil {
+				err = root.Remove(relPath)
+			}
 		} else {
+			err = ensureRootedSameFile(root, relPath, fileInfo)
+			closeErr := file.Close()
+			if err == nil {
+				err = closeErr
+			}
+			if err != nil {
+				stats.Errors++
+				if verbose {
+					fmt.Fprintf(os.Stderr, "  warning: cannot purge %s: %v\n", relPath, err)
+				}
+				continue
+			}
 			err = root.Remove(relPath)
 		}
 		if err != nil {
@@ -896,7 +931,10 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 	return stats, nil
 }
 
-var errPathHasSymlink = errors.New("path contains symlink")
+var (
+	errPathHasSymlink = errors.New("path contains symlink")
+	errPathChanged    = errors.New("path changed after validation")
+)
 
 // purgeAfterPathCheck is a test hook for exercising path-swap races.
 var purgeAfterPathCheck = func(string) {}
@@ -929,35 +967,59 @@ func lstatNoSymlinkComponents(root *os.Root, relPath string) (os.FileInfo, error
 	return info, nil
 }
 
-func shredRootedFile(root *os.Root, relPath string, size int64) error {
-	f, err := root.OpenFile(relPath, os.O_WRONLY, 0)
+func openRootedSameFile(root *os.Root, relPath string, expected os.FileInfo, flag int) (*os.File, os.FileInfo, error) {
+	f, err := root.OpenFile(relPath, flag, 0)
 	if err != nil {
-		return fmt.Errorf("opening %s for overwrite: %w", relPath, err)
+		return nil, nil, err
 	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, nil, err
+	}
+	if !info.Mode().IsRegular() || !os.SameFile(expected, info) {
+		_ = f.Close()
+		return nil, nil, errPathChanged
+	}
+	return f, info, nil
+}
 
+func ensureRootedSameFile(root *os.Root, relPath string, expected os.FileInfo) error {
+	info, err := root.Lstat(relPath)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() || !os.SameFile(expected, info) {
+		return errPathChanged
+	}
+	return nil
+}
+
+func shredOpenFile(f *os.File, relPath string, size int64) error {
+	if _, err := f.Seek(0, 0); err != nil {
+		f.Close()
+		return fmt.Errorf("seeking %s: %w", relPath, err)
+	}
 	buf := make([]byte, min(size, 64*1024))
 	for written := int64(0); written < size; {
 		chunk := int(min(int64(len(buf)), size-written))
 		if _, err := cryptorand.Read(buf[:chunk]); err != nil {
-			f.Close()
+			_ = f.Close()
 			return fmt.Errorf("generating overwrite bytes for %s: %w", relPath, err)
 		}
 		if _, err := f.Write(buf[:chunk]); err != nil {
-			f.Close()
+			_ = f.Close()
 			return fmt.Errorf("overwriting %s: %w", relPath, err)
 		}
 		written += int64(chunk)
 	}
 
 	if err := f.Sync(); err != nil {
-		f.Close()
+		_ = f.Close()
 		return fmt.Errorf("syncing %s: %w", relPath, err)
 	}
 	if err := f.Close(); err != nil {
 		return fmt.Errorf("closing %s: %w", relPath, err)
-	}
-	if err := root.Remove(relPath); err != nil {
-		return fmt.Errorf("removing %s: %w", relPath, err)
 	}
 	return nil
 }
@@ -1373,14 +1435,28 @@ func Rotate(cfg *config.Config, oldIdentity age.Identity, newRecipient age.Recip
 // key before Rotate, this error means the old key should be restored.
 var ErrRotationStoreUnchanged = errors.New("rotation left object store encrypted with old key")
 
+// ErrRotationStoreAmbiguous marks a catastrophic rotation failure where neither
+// rollback nor roll-forward could prove a single-key object-store state.
+var ErrRotationStoreAmbiguous = errors.New("rotation left object store in ambiguous key state")
+
 // IsRotationStoreUnchanged reports whether a rotation error left the object
 // store decryptable with the old key.
 func IsRotationStoreUnchanged(err error) bool {
 	return errors.Is(err, ErrRotationStoreUnchanged)
 }
 
+// IsRotationStoreAmbiguous reports whether a rotation error could not recover
+// the object store to a proven old-key or new-key state.
+func IsRotationStoreAmbiguous(err error) bool {
+	return errors.Is(err, ErrRotationStoreAmbiguous)
+}
+
 func rotationStoreUnchangedError(err error) error {
 	return fmt.Errorf("%w: %w", ErrRotationStoreUnchanged, err)
+}
+
+func rotationStoreAmbiguousError(err error) error {
+	return fmt.Errorf("%w: %w", ErrRotationStoreAmbiguous, err)
 }
 
 // rotateObjectWrite is a test hook for exercising apply/rollback failures.
@@ -1395,11 +1471,11 @@ func recoverRotationApplyFailure(store *ObjectStore, oldRoot, newRoot string, al
 	}
 
 	if forwardErr := rollForwardRotatedObjects(store, newRoot, allHashes); forwardErr != nil {
-		return errors.Join(
+		return rotationStoreAmbiguousError(errors.Join(
 			cause,
 			fmt.Errorf("rollback failed: %w", rollbackErr),
 			fmt.Errorf("new-key recovery failed: %w", forwardErr),
-		)
+		))
 	}
 
 	return errors.Join(

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -888,29 +888,7 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 			continue
 		}
 
-		if shred {
-			err = shredOpenFile(file, relPath, fileInfo.Size())
-			if err == nil {
-				err = ensureRootedSameFile(root, relPath, fileInfo)
-			}
-			if err == nil {
-				err = root.Remove(relPath)
-			}
-		} else {
-			err = ensureRootedSameFile(root, relPath, fileInfo)
-			closeErr := file.Close()
-			if err == nil {
-				err = closeErr
-			}
-			if err != nil {
-				stats.Errors++
-				if verbose {
-					fmt.Fprintf(os.Stderr, "  warning: cannot purge %s: %v\n", relPath, err)
-				}
-				continue
-			}
-			err = root.Remove(relPath)
-		}
+		err = purgeOpenRootedFile(root, relPath, file, fileInfo, shred)
 		if err != nil {
 			stats.Errors++
 			if verbose {
@@ -938,6 +916,9 @@ var (
 
 // purgeAfterPathCheck is a test hook for exercising path-swap races.
 var purgeAfterPathCheck = func(string) {}
+
+// purgeBeforeQuarantine is a test hook for exercising final remove races.
+var purgeBeforeQuarantine = func(string) {}
 
 func lstatNoSymlinkComponents(root *os.Root, relPath string) (os.FileInfo, error) {
 	clean := filepath.Clean(relPath)
@@ -993,6 +974,73 @@ func ensureRootedSameFile(root *os.Root, relPath string, expected os.FileInfo) e
 		return errPathChanged
 	}
 	return nil
+}
+
+func purgeOpenRootedFile(root *os.Root, relPath string, f *os.File, info os.FileInfo, shred bool) error {
+	purgeBeforeQuarantine(relPath)
+	tombstone, tombDir, err := quarantineRootedSameFile(root, relPath, info)
+	if err != nil {
+		_ = f.Close()
+		return err
+	}
+
+	if shred {
+		err = shredOpenFile(f, relPath, info.Size())
+	} else {
+		err = f.Close()
+	}
+	if err != nil {
+		return err
+	}
+	if err := root.Remove(tombstone); err != nil {
+		return fmt.Errorf("removing %s: %w", relPath, err)
+	}
+	_ = root.Remove(tombDir)
+	return nil
+}
+
+func quarantineRootedSameFile(root *os.Root, relPath string, expected os.FileInfo) (string, string, error) {
+	parent := filepath.Dir(relPath)
+	base := filepath.Base(relPath)
+	for range 16 {
+		suffix, err := randomPurgeSuffix()
+		if err != nil {
+			return "", "", err
+		}
+		tombDir := filepath.Join(parent, ".enclaude-purge-"+suffix)
+		if err := root.Mkdir(tombDir, 0700); err != nil {
+			if os.IsExist(err) {
+				continue
+			}
+			return "", "", err
+		}
+		tombstone := filepath.Join(tombDir, base)
+		if err := root.Rename(relPath, tombstone); err != nil {
+			_ = root.Remove(tombDir)
+			return "", "", err
+		}
+		tombInfo, err := root.Lstat(tombstone)
+		if err != nil {
+			_ = root.Rename(tombstone, relPath)
+			_ = root.Remove(tombDir)
+			return "", "", err
+		}
+		if !tombInfo.Mode().IsRegular() || !os.SameFile(expected, tombInfo) {
+			_ = root.Rename(tombstone, relPath)
+			_ = root.Remove(tombDir)
+			return "", "", errPathChanged
+		}
+		return tombstone, tombDir, nil
+	}
+	return "", "", fmt.Errorf("creating unique purge tombstone")
+}
+
+func randomPurgeSuffix() (string, error) {
+	buf := make([]byte, 8)
+	if _, err := cryptorand.Read(buf); err != nil {
+		return "", fmt.Errorf("reading random bytes: %w", err)
+	}
+	return fmt.Sprintf("%x", buf), nil
 }
 
 func shredOpenFile(f *os.File, relPath string, size int64) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -878,9 +878,9 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 			continue
 		}
 
-		stats.Bytes += int64(len(plaintext))
 		if dryRun {
 			_ = file.Close()
+			stats.Bytes += int64(len(plaintext))
 			stats.Removed++
 			if verbose {
 				fmt.Printf("  [purge] %s (%s)\n", relPath, FormatSize(int64(len(plaintext))))
@@ -896,6 +896,7 @@ func PurgePlaintext(cfg *config.Config, identity age.Identity, scope PurgeScope,
 			}
 			continue
 		}
+		stats.Bytes += int64(len(plaintext))
 		stats.Removed++
 		if verbose {
 			fmt.Printf("  [purge] %s (%s)\n", relPath, FormatSize(int64(len(plaintext))))
@@ -968,17 +969,6 @@ func openRootedSameFile(root *os.Root, relPath string, expected os.FileInfo, fla
 	return f, info, nil
 }
 
-func ensureRootedSameFile(root *os.Root, relPath string, expected os.FileInfo) error {
-	info, err := root.Lstat(relPath)
-	if err != nil {
-		return err
-	}
-	if !info.Mode().IsRegular() || !os.SameFile(expected, info) {
-		return errPathChanged
-	}
-	return nil
-}
-
 func purgeOpenRootedFile(root *os.Root, relPath string, f *os.File, info os.FileInfo, expectedHash string, shred bool) error {
 	purgeBeforeQuarantine(relPath)
 	tombstone, tombDir, err := quarantineRootedSameFile(root, relPath, info)
@@ -1010,7 +1000,7 @@ func quarantineRootedSameFile(root *os.Root, relPath string, expected os.FileInf
 	parent := filepath.Dir(relPath)
 	base := filepath.Base(relPath)
 	for range 16 {
-		suffix, err := randomPurgeSuffix()
+		suffix, err := RandomHex(8)
 		if err != nil {
 			return "", "", err
 		}
@@ -1100,8 +1090,9 @@ func rootedFileMatchesHash(root *os.Root, relPath string, expected os.FileInfo, 
 	return ContentHash(data) == expectedHash, nil
 }
 
-func randomPurgeSuffix() (string, error) {
-	buf := make([]byte, 8)
+// RandomHex returns n cryptographically random bytes encoded as a hex string.
+func RandomHex(n int) (string, error) {
+	buf := make([]byte, n)
 	if _, err := cryptorand.Read(buf); err != nil {
 		return "", fmt.Errorf("reading random bytes: %w", err)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -321,6 +321,53 @@ func TestPurgePlaintextSkipsSymlink(t *testing.T) {
 	}
 }
 
+// TestPurgePlaintextSkipsSymlinkedParent verifies purge rejects symlinks in
+// every managed path component, not only the final file.
+func TestPurgePlaintextSkipsSymlinkedParent(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+	if _, err := Seal(cfg, identity.Recipient(), false, nil); err != nil {
+		t.Fatalf("Seal() error: %v", err)
+	}
+
+	sessionRel := "projects/proj-a/abc123.jsonl"
+	sessionPath := filepath.Join(claudeDir, sessionRel)
+	sessionContent, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outsideDir := t.TempDir()
+	targetPath := filepath.Join(outsideDir, "abc123.jsonl")
+	if err := os.WriteFile(targetPath, sessionContent, 0600); err != nil {
+		t.Fatal(err)
+	}
+	projDir := filepath.Join(claudeDir, "projects/proj-a")
+	if err := os.RemoveAll(projDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsideDir, projDir); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	stats, err := PurgePlaintext(cfg, identity, PurgeCompletedSessions, true, false, false)
+	if err != nil {
+		t.Fatalf("PurgePlaintext() error: %v", err)
+	}
+	if stats.Removed != 0 || stats.Skipped != 1 {
+		t.Fatalf("stats = %s, want 0 removed and 1 skipped", stats)
+	}
+	if got, err := os.ReadFile(targetPath); err != nil || !bytes.Equal(got, sessionContent) {
+		t.Fatalf("symlink target changed or unreadable: got %q err=%v", got, err)
+	}
+	if info, err := os.Lstat(projDir); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("project directory symlink should remain skipped: info=%v err=%v", info, err)
+	}
+}
+
 func TestSealIdempotent(t *testing.T) {
 	claudeDir := setupTestDir(t)
 	sealDir := t.TempDir()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -368,6 +368,9 @@ func TestPurgePlaintextSkipsSymlinkedParent(t *testing.T) {
 	}
 }
 
+// TestPurgePlaintextRootedReadBlocksSymlinkSwap verifies that a symlink swapped
+// into a managed path after the precheck cannot redirect purge to a file outside
+// ClaudeDir; the rooted re-open detects the change and errors instead of removing.
 func TestPurgePlaintextRootedReadBlocksSymlinkSwap(t *testing.T) {
 	claudeDir := setupTestDir(t)
 	sealDir := t.TempDir()
@@ -423,6 +426,9 @@ func TestPurgePlaintextRootedReadBlocksSymlinkSwap(t *testing.T) {
 	}
 }
 
+// TestPurgePlaintextShredRejectsInRootPathSwap verifies that an in-root symlink
+// swapped in after the precheck is rejected, so --shred cannot overwrite a
+// different in-root target than the file that was hash-verified.
 func TestPurgePlaintextShredRejectsInRootPathSwap(t *testing.T) {
 	claudeDir := setupTestDir(t)
 	sealDir := t.TempDir()
@@ -480,6 +486,9 @@ func TestPurgePlaintextShredRejectsInRootPathSwap(t *testing.T) {
 	}
 }
 
+// TestPurgePlaintextRejectsFinalRemovePathSwap verifies that a managed file
+// replaced between hash verification and quarantine is detected via the
+// same-file check and left in place rather than removed.
 func TestPurgePlaintextRejectsFinalRemovePathSwap(t *testing.T) {
 	claudeDir := setupTestDir(t)
 	sealDir := t.TempDir()
@@ -525,6 +534,9 @@ func TestPurgePlaintextRejectsFinalRemovePathSwap(t *testing.T) {
 	}
 }
 
+// TestPurgePlaintextRestoresAfterPostQuarantineFailure verifies that a failure
+// after quarantine restores the original, still-intact plaintext and leaves no
+// purge tombstone behind.
 func TestPurgePlaintextRestoresAfterPostQuarantineFailure(t *testing.T) {
 	claudeDir := setupTestDir(t)
 	sealDir := t.TempDir()
@@ -571,6 +583,10 @@ func TestPurgePlaintextRestoresAfterPostQuarantineFailure(t *testing.T) {
 	assertNoPurgeTombstones(t, claudeDir)
 }
 
+// TestPurgePlaintextRemovesCorruptPostQuarantineFailure verifies that a failure
+// after the quarantined bytes were already corrupted removes the file — the
+// sealed object is recoverable — rather than restoring corruption, leaving no
+// tombstone behind.
 func TestPurgePlaintextRemovesCorruptPostQuarantineFailure(t *testing.T) {
 	claudeDir := setupTestDir(t)
 	sealDir := t.TempDir()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -197,7 +197,7 @@ func TestPurgePlaintextCompletedSessionsOnly(t *testing.T) {
 		t.Fatalf("Seal() error: %v", err)
 	}
 
-	stats, err := PurgePlaintext(cfg, PurgeCompletedSessions, false, false, false)
+	stats, err := PurgePlaintext(cfg, identity, PurgeCompletedSessions, false, false, false)
 	if err != nil {
 		t.Fatalf("PurgePlaintext() error: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestPurgePlaintextSkipsChangedPlaintext(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stats, err := PurgePlaintext(cfg, PurgeCompletedSessions, false, false, false)
+	stats, err := PurgePlaintext(cfg, identity, PurgeCompletedSessions, false, false, false)
 	if err != nil {
 		t.Fatalf("PurgePlaintext() error: %v", err)
 	}
@@ -246,6 +246,78 @@ func TestPurgePlaintextSkipsChangedPlaintext(t *testing.T) {
 	}
 	if _, err := os.Stat(sessionPath); err != nil {
 		t.Fatalf("changed plaintext should remain: %v", err)
+	}
+}
+
+// TestPurgePlaintextRequiresRecoverableObject verifies purge will not remove
+// plaintext when the encrypted object is absent, because that plaintext may be
+// the only usable copy.
+func TestPurgePlaintextRequiresRecoverableObject(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+	if _, err := Seal(cfg, identity.Recipient(), false, nil); err != nil {
+		t.Fatalf("Seal() error: %v", err)
+	}
+
+	manifest, _ := LoadManifest(sealDir)
+	sessionRel := "projects/proj-a/abc123.jsonl"
+	hash := manifest.Files[sessionRel].ContentHash
+	if err := os.Remove(NewObjectStore(sealDir).ObjectPath(hash)); err != nil {
+		t.Fatalf("removing sealed object: %v", err)
+	}
+
+	stats, err := PurgePlaintext(cfg, identity, PurgeCompletedSessions, false, false, false)
+	if err != nil {
+		t.Fatalf("PurgePlaintext() error: %v", err)
+	}
+	if stats.Removed != 0 || stats.Errors != 1 {
+		t.Fatalf("stats = %s, want 0 removed and 1 error", stats)
+	}
+	if _, err := os.Stat(filepath.Join(claudeDir, sessionRel)); err != nil {
+		t.Fatalf("plaintext should remain when sealed object is missing: %v", err)
+	}
+}
+
+// TestPurgePlaintextSkipsSymlink verifies purge never follows a managed path
+// symlink, which would let --shred overwrite a target outside ClaudeDir.
+func TestPurgePlaintextSkipsSymlink(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+	if _, err := Seal(cfg, identity.Recipient(), false, nil); err != nil {
+		t.Fatalf("Seal() error: %v", err)
+	}
+
+	sessionPath := filepath.Join(claudeDir, "projects/proj-a/abc123.jsonl")
+	targetPath := filepath.Join(t.TempDir(), "outside.jsonl")
+	targetContent := []byte(`{"type":"user"}`)
+	if err := os.WriteFile(targetPath, targetContent, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(sessionPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(targetPath, sessionPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	stats, err := PurgePlaintext(cfg, identity, PurgeCompletedSessions, true, false, false)
+	if err != nil {
+		t.Fatalf("PurgePlaintext() error: %v", err)
+	}
+	if stats.Removed != 0 || stats.Skipped != 1 {
+		t.Fatalf("stats = %s, want 0 removed and 1 skipped", stats)
+	}
+	if got, err := os.ReadFile(targetPath); err != nil || !bytes.Equal(got, targetContent) {
+		t.Fatalf("symlink target changed or unreadable: got %q err=%v", got, err)
+	}
+	if info, err := os.Lstat(sessionPath); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("symlink should remain skipped: info=%v err=%v", info, err)
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -423,6 +423,63 @@ func TestPurgePlaintextRootedReadBlocksSymlinkSwap(t *testing.T) {
 	}
 }
 
+func TestPurgePlaintextShredRejectsInRootPathSwap(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+	if _, err := Seal(cfg, identity.Recipient(), false, nil); err != nil {
+		t.Fatalf("Seal() error: %v", err)
+	}
+
+	sessionRel := "projects/proj-a/abc123.jsonl"
+	sessionContent, err := os.ReadFile(filepath.Join(claudeDir, sessionRel))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	targetDir := filepath.Join(claudeDir, "race-target")
+	if err := os.MkdirAll(targetDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	targetPath := filepath.Join(targetDir, "abc123.jsonl")
+	if err := os.WriteFile(targetPath, sessionContent, 0600); err != nil {
+		t.Fatal(err)
+	}
+	projDir := filepath.Join(claudeDir, "projects/proj-a")
+
+	originalHook := purgeAfterPathCheck
+	swapped := false
+	purgeAfterPathCheck = func(relPath string) {
+		if swapped || relPath != sessionRel {
+			return
+		}
+		swapped = true
+		if err := os.RemoveAll(projDir); err != nil {
+			t.Fatalf("removing project dir during purge race: %v", err)
+		}
+		if err := os.Symlink("../race-target", projDir); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+	}
+	t.Cleanup(func() { purgeAfterPathCheck = originalHook })
+
+	stats, err := PurgePlaintext(cfg, identity, PurgeCompletedSessions, true, false, false)
+	if err != nil {
+		t.Fatalf("PurgePlaintext() error: %v", err)
+	}
+	if !swapped {
+		t.Fatal("test hook did not run")
+	}
+	if stats.Removed != 0 || stats.Errors != 1 {
+		t.Fatalf("stats = %s, want 0 removed and 1 error", stats)
+	}
+	if got, err := os.ReadFile(targetPath); err != nil || !bytes.Equal(got, sessionContent) {
+		t.Fatalf("in-root swap target changed or unreadable: got %q err=%v", got, err)
+	}
+}
+
 func TestSealIdempotent(t *testing.T) {
 	claudeDir := setupTestDir(t)
 	sealDir := t.TempDir()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -184,6 +184,71 @@ func TestSealUnsealRoundTrip(t *testing.T) {
 	}
 }
 
+// TestPurgePlaintextCompletedSessionsOnly verifies the default purge scope
+// removes only sealed top-level completed session transcripts, leaving history,
+// memory, settings, and nested subagent JSONL files in place.
+func TestPurgePlaintextCompletedSessionsOnly(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+	if _, err := Seal(cfg, identity.Recipient(), false, nil); err != nil {
+		t.Fatalf("Seal() error: %v", err)
+	}
+
+	stats, err := PurgePlaintext(cfg, PurgeCompletedSessions, false, false, false)
+	if err != nil {
+		t.Fatalf("PurgePlaintext() error: %v", err)
+	}
+	if stats.Removed != 1 {
+		t.Fatalf("Removed = %d, want 1 (%s)", stats.Removed, stats)
+	}
+
+	if _, err := os.Stat(filepath.Join(claudeDir, "projects/proj-a/abc123.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("top-level session still exists or stat failed unexpectedly: %v", err)
+	}
+	for _, rel := range []string{
+		"history.jsonl",
+		"settings.json",
+		"projects/proj-a/memory/MEMORY.md",
+		"projects/proj-a/subagents/agent-abc.jsonl",
+	} {
+		if _, err := os.Stat(filepath.Join(claudeDir, rel)); err != nil {
+			t.Fatalf("%s should remain after completed-session purge: %v", rel, err)
+		}
+	}
+}
+
+// TestPurgePlaintextSkipsChangedPlaintext guards against deleting unsynced
+// edits: a candidate file must still hash to the sealed manifest entry.
+func TestPurgePlaintextSkipsChangedPlaintext(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+	if _, err := Seal(cfg, identity.Recipient(), false, nil); err != nil {
+		t.Fatalf("Seal() error: %v", err)
+	}
+
+	sessionPath := filepath.Join(claudeDir, "projects/proj-a/abc123.jsonl")
+	if err := os.WriteFile(sessionPath, []byte(`{"type":"user","message":"unsynced"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := PurgePlaintext(cfg, PurgeCompletedSessions, false, false, false)
+	if err != nil {
+		t.Fatalf("PurgePlaintext() error: %v", err)
+	}
+	if stats.Removed != 0 || stats.Skipped != 1 {
+		t.Fatalf("stats = %s, want 0 removed and 1 skipped", stats)
+	}
+	if _, err := os.Stat(sessionPath); err != nil {
+		t.Fatalf("changed plaintext should remain: %v", err)
+	}
+}
+
 func TestSealIdempotent(t *testing.T) {
 	claudeDir := setupTestDir(t)
 	sealDir := t.TempDir()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -368,6 +368,61 @@ func TestPurgePlaintextSkipsSymlinkedParent(t *testing.T) {
 	}
 }
 
+func TestPurgePlaintextRootedReadBlocksSymlinkSwap(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+	if _, err := Seal(cfg, identity.Recipient(), false, nil); err != nil {
+		t.Fatalf("Seal() error: %v", err)
+	}
+
+	sessionRel := "projects/proj-a/abc123.jsonl"
+	sessionPath := filepath.Join(claudeDir, sessionRel)
+	sessionContent, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outsideDir := t.TempDir()
+	targetPath := filepath.Join(outsideDir, "abc123.jsonl")
+	if err := os.WriteFile(targetPath, sessionContent, 0600); err != nil {
+		t.Fatal(err)
+	}
+	projDir := filepath.Join(claudeDir, "projects/proj-a")
+
+	originalHook := purgeAfterPathCheck
+	swapped := false
+	purgeAfterPathCheck = func(relPath string) {
+		if swapped || relPath != sessionRel {
+			return
+		}
+		swapped = true
+		if err := os.RemoveAll(projDir); err != nil {
+			t.Fatalf("removing project dir during purge race: %v", err)
+		}
+		if err := os.Symlink(outsideDir, projDir); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+	}
+	t.Cleanup(func() { purgeAfterPathCheck = originalHook })
+
+	stats, err := PurgePlaintext(cfg, identity, PurgeCompletedSessions, true, false, false)
+	if err != nil {
+		t.Fatalf("PurgePlaintext() error: %v", err)
+	}
+	if !swapped {
+		t.Fatal("test hook did not run")
+	}
+	if stats.Removed != 0 || stats.Errors != 1 {
+		t.Fatalf("stats = %s, want 0 removed and 1 error", stats)
+	}
+	if got, err := os.ReadFile(targetPath); err != nil || !bytes.Equal(got, sessionContent) {
+		t.Fatalf("symlink target changed or unreadable: got %q err=%v", got, err)
+	}
+}
+
 func TestSealIdempotent(t *testing.T) {
 	claudeDir := setupTestDir(t)
 	sealDir := t.TempDir()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -568,6 +568,59 @@ func TestPurgePlaintextRestoresAfterPostQuarantineFailure(t *testing.T) {
 	if got, err := os.ReadFile(sessionPath); err != nil || !bytes.Equal(got, original) {
 		t.Fatalf("original file was not restored: got %q err=%v", got, err)
 	}
+	assertNoPurgeTombstones(t, claudeDir)
+}
+
+func TestPurgePlaintextRemovesCorruptPostQuarantineFailure(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+	if _, err := Seal(cfg, identity.Recipient(), false, nil); err != nil {
+		t.Fatalf("Seal() error: %v", err)
+	}
+
+	sessionRel := "projects/proj-a/abc123.jsonl"
+	sessionPath := filepath.Join(claudeDir, sessionRel)
+
+	originalHook := purgeAfterQuarantine
+	corrupted := false
+	purgeAfterQuarantine = func(relPath string, f *os.File) {
+		if corrupted || relPath != sessionRel {
+			return
+		}
+		corrupted = true
+		if _, err := f.Seek(0, 0); err != nil {
+			t.Fatalf("seeking quarantined file in hook: %v", err)
+		}
+		if _, err := f.Write([]byte("corrupt")); err != nil {
+			t.Fatalf("corrupting quarantined file in hook: %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("closing quarantined file in hook: %v", err)
+		}
+	}
+	t.Cleanup(func() { purgeAfterQuarantine = originalHook })
+
+	stats, err := PurgePlaintext(cfg, identity, PurgeCompletedSessions, true, false, false)
+	if err != nil {
+		t.Fatalf("PurgePlaintext() error: %v", err)
+	}
+	if !corrupted {
+		t.Fatal("test hook did not run")
+	}
+	if stats.Removed != 0 || stats.Errors != 1 {
+		t.Fatalf("stats = %s, want 0 removed and 1 error", stats)
+	}
+	if _, err := os.Stat(sessionPath); !os.IsNotExist(err) {
+		t.Fatalf("corrupt file should not be restored: %v", err)
+	}
+	assertNoPurgeTombstones(t, claudeDir)
+}
+
+func assertNoPurgeTombstones(t *testing.T, claudeDir string) {
+	t.Helper()
 	matches, err := filepath.Glob(filepath.Join(claudeDir, "projects/proj-a/.enclaude-purge-*"))
 	if err != nil {
 		t.Fatal(err)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -525,6 +525,58 @@ func TestPurgePlaintextRejectsFinalRemovePathSwap(t *testing.T) {
 	}
 }
 
+func TestPurgePlaintextRestoresAfterPostQuarantineFailure(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+	if _, err := Seal(cfg, identity.Recipient(), false, nil); err != nil {
+		t.Fatalf("Seal() error: %v", err)
+	}
+
+	sessionRel := "projects/proj-a/abc123.jsonl"
+	sessionPath := filepath.Join(claudeDir, sessionRel)
+	original, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalHook := purgeAfterQuarantine
+	closed := false
+	purgeAfterQuarantine = func(relPath string, f *os.File) {
+		if closed || relPath != sessionRel {
+			return
+		}
+		closed = true
+		if err := f.Close(); err != nil {
+			t.Fatalf("closing quarantined file in hook: %v", err)
+		}
+	}
+	t.Cleanup(func() { purgeAfterQuarantine = originalHook })
+
+	stats, err := PurgePlaintext(cfg, identity, PurgeCompletedSessions, false, false, false)
+	if err != nil {
+		t.Fatalf("PurgePlaintext() error: %v", err)
+	}
+	if !closed {
+		t.Fatal("test hook did not run")
+	}
+	if stats.Removed != 0 || stats.Errors != 1 {
+		t.Fatalf("stats = %s, want 0 removed and 1 error", stats)
+	}
+	if got, err := os.ReadFile(sessionPath); err != nil || !bytes.Equal(got, original) {
+		t.Fatalf("original file was not restored: got %q err=%v", got, err)
+	}
+	matches, err := filepath.Glob(filepath.Join(claudeDir, "projects/proj-a/.enclaude-purge-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("left purge tombstone directories: %v", matches)
+	}
+}
+
 func TestSealIdempotent(t *testing.T) {
 	claudeDir := setupTestDir(t)
 	sealDir := t.TempDir()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -480,6 +480,51 @@ func TestPurgePlaintextShredRejectsInRootPathSwap(t *testing.T) {
 	}
 }
 
+func TestPurgePlaintextRejectsFinalRemovePathSwap(t *testing.T) {
+	claudeDir := setupTestDir(t)
+	sealDir := t.TempDir()
+
+	identity, _ := crypto.GenerateKey()
+	cfg := config.DefaultConfig(claudeDir, sealDir)
+	if _, err := Seal(cfg, identity.Recipient(), false, nil); err != nil {
+		t.Fatalf("Seal() error: %v", err)
+	}
+
+	sessionRel := "projects/proj-a/abc123.jsonl"
+	sessionPath := filepath.Join(claudeDir, sessionRel)
+	replacement := []byte(`{"type":"user","message":"replacement"}`)
+
+	originalHook := purgeBeforeQuarantine
+	swapped := false
+	purgeBeforeQuarantine = func(relPath string) {
+		if swapped || relPath != sessionRel {
+			return
+		}
+		swapped = true
+		if err := os.Remove(sessionPath); err != nil {
+			t.Fatalf("removing original during purge race: %v", err)
+		}
+		if err := os.WriteFile(sessionPath, replacement, 0600); err != nil {
+			t.Fatalf("writing replacement during purge race: %v", err)
+		}
+	}
+	t.Cleanup(func() { purgeBeforeQuarantine = originalHook })
+
+	stats, err := PurgePlaintext(cfg, identity, PurgeCompletedSessions, false, false, false)
+	if err != nil {
+		t.Fatalf("PurgePlaintext() error: %v", err)
+	}
+	if !swapped {
+		t.Fatal("test hook did not run")
+	}
+	if stats.Removed != 0 || stats.Errors != 1 {
+		t.Fatalf("stats = %s, want 0 removed and 1 error", stats)
+	}
+	if got, err := os.ReadFile(sessionPath); err != nil || !bytes.Equal(got, replacement) {
+		t.Fatalf("replacement file changed or unreadable: got %q err=%v", got, err)
+	}
+}
+
 func TestSealIdempotent(t *testing.T) {
 	claudeDir := setupTestDir(t)
 	sealDir := t.TempDir()

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -58,7 +58,7 @@ func ReadPassphrase(prompt string, confirm bool) (string, error) {
 func ReadPassphraseOptional(prompt string) (string, error) {
 	fd := int(os.Stdin.Fd())
 	if !term.IsTerminal(fd) {
-		return "", fmt.Errorf("cannot prompt for passphrase: stdin is not a terminal")
+		return "", nil
 	}
 	fmt.Fprint(os.Stderr, prompt)
 	pw, err := term.ReadPassword(fd)

--- a/internal/ui/prompt_test.go
+++ b/internal/ui/prompt_test.go
@@ -72,3 +72,15 @@ func TestSanitizePassphrase_OnlyNewlineBecomesEmpty(t *testing.T) {
 		t.Fatalf("got %q, want empty", got)
 	}
 }
+
+// TestReadPassphraseOptional_NonTTYSkips verifies optional backup prompts do
+// not make non-interactive init fail. go test runs with non-terminal stdin.
+func TestReadPassphraseOptional_NonTTYSkips(t *testing.T) {
+	got, err := ReadPassphraseOptional("optional: ")
+	if err != nil {
+		t.Fatalf("ReadPassphraseOptional() error = %v", err)
+	}
+	if got != "" {
+		t.Fatalf("ReadPassphraseOptional() = %q, want empty skip", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add a plaintext purge workflow with manifest/hash checks, recoverability checks, symlink/path-swap hardening, and optional shredding
- make key rotation all-or-nothing with staged objects, rollback/recovery handling, and emergency recovery key preservation for ambiguous failures
- tighten recovery key file creation and purge tombstone cleanup based on roborev feedback

## Verification
- go test ./... -count=1
- git diff --check
- make build
- roborev auto review 1298 passed