### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unhandled rand.Read errors

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,7 @@
 **Vulnerability:** The `ObjectStore` methods (`Write`, `Read`, `Delete`, `Exists`, `Size`) constructed file paths using `filepath.Join(s.dir, hash[:2], hash[2:]+".age")` without verifying that `hash` was a valid SHA-256 hex string. A malicious manifest could provide a `content_hash` like `"../../etc/passwd"`, causing the joined path to escape the `objects/` directory and allowing arbitrary file reads/writes/deletions.
 **Learning:** Even when a string is intended to be an internal ID or hash, if it originates from external/untrusted sources (like a synced manifest) and is used in path construction, it must be strictly validated.
 **Prevention:** Enforce strict validation on object IDs (e.g., ensuring they are exactly 64 characters of lowercase hexadecimal `[0-9a-f]`) before using them in filesystem operations.
+## 2026-07-06 - Unhandled rand.Read Error Vulnerability
+**Vulnerability:** Unchecked errors from `crypto/rand.Read`. If it fails, the provided buffer remains uninitialized (typically all zeros).
+**Learning:** In security-sensitive operations (e.g., generating device IDs or shredding files with random data), silently proceeding after `rand.Read` fails can lead to predictable identifiers or insecure data wiping.
+**Prevention:** Always check the error returned by `rand.Read` and handle it securely, either by aborting the operation or using a safe fallback (like a high-precision timestamp for non-cryptographic identifiers).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -150,6 +151,9 @@ func (c *Config) Save(sealDir string) error {
 func generateDeviceID() string {
 	hostname, _ := os.Hostname()
 	b := make([]byte, 4)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback to timestamp if random generation fails
+		return fmt.Sprintf("%s-%x", hostname, time.Now().UnixNano())
+	}
 	return fmt.Sprintf("%s-%x", hostname, b)
 }

--- a/internal/crypto/shred.go
+++ b/internal/crypto/shred.go
@@ -25,7 +25,10 @@ func ShredFile(path string) error {
 	buf := make([]byte, min(size, 64*1024))
 	for written := int64(0); written < size; {
 		n := min(int64(len(buf)), size-written)
-		rand.Read(buf[:n])
+		if _, err := rand.Read(buf[:n]); err != nil {
+			f.Close()
+			return fmt.Errorf("generating overwrite bytes for %s: %w", path, err)
+		}
 		if _, err := f.Write(buf[:n]); err != nil {
 			f.Close()
 			return fmt.Errorf("overwriting %s: %w", path, err)


### PR DESCRIPTION
🎯 **What:**
Fixed unhandled `crypto/rand.Read` errors in two locations:
1. `internal/config/config.go` (`generateDeviceID`)
2. `internal/crypto/shred.go` (`ShredFile`)

⚠️ **Risk:**
When `crypto/rand.Read` fails (e.g., due to entropy exhaustion), the provided buffer remains uninitialized (typically all zeros).
- For `generateDeviceID`, this could lead to predictable or duplicate device IDs across multiple machines if the random read fails.
- For `ShredFile`, this would cause the file to be overwritten with all zeros instead of random data, silently failing to meet the intended shredding behavior.

🛡️ **Solution:**
- Added error checks for `rand.Read()`.
- In `generateDeviceID`, implemented a fallback using `time.Now().UnixNano()` to guarantee a unique ID even if random byte generation fails.
- In `ShredFile`, properly abort the operation and return an error if random data cannot be generated, preventing an insecure or incomplete shredding operation.

✅ **Verification:**
- Ran `gosec` to verify that `G104` errors are resolved for these lines.
- Ran all tests (`go test ./...`) which pass successfully.

---
*PR created automatically by Jules for task [4462401516982979011](https://jules.google.com/task/4462401516982979011) started by @coredipper*