### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unhandled rand.Read error in benchmarks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** Unchecked errors from `crypto/rand.Read`. If it fails, the provided buffer remains uninitialized (typically all zeros).
 **Learning:** In security-sensitive operations (e.g., generating device IDs or shredding files with random data), silently proceeding after `rand.Read` fails can lead to predictable identifiers or insecure data wiping.
 **Prevention:** Always check the error returned by `rand.Read` and handle it securely, either by aborting the operation or using a safe fallback (like a high-precision timestamp for non-cryptographic identifiers).
+
+## 2026-07-06 - Unhandled rand.Read Error in Benchmarks Vulnerability
+**Vulnerability:** Unchecked errors from `math/rand.Read` or `crypto/rand.Read` in benchmark tests.
+**Learning:** Unhandled random generation errors in benchmarks can lead to measuring the performance of predictable (zeroed) data generation or processing instead of actual random data processing, potentially skewing benchmark results or hiding actual errors.
+**Prevention:** Even in tests and benchmarks, always check the error returned by `rand.Read` and use `b.Fatalf` or `t.Fatalf` to abort the execution if it fails.

--- a/internal/store/store_bench_test.go
+++ b/internal/store/store_bench_test.go
@@ -25,7 +25,9 @@ func BenchmarkStatus(b *testing.B) {
 
 	for i := 0; i < 1000; i++ {
 		content := make([]byte, 100*1024)
-		rand.Read(content)
+		if _, err := rand.Read(content); err != nil {
+			b.Fatalf("failed to generate random data: %v", err)
+		}
 		os.WriteFile(filepath.Join(claudeDir, fmt.Sprintf("file-%d.txt", i)), content, 0644)
 	}
 
@@ -69,7 +71,9 @@ func BenchmarkUnsealStatus(b *testing.B) {
 
 	for i := 0; i < 1000; i++ {
 		content := make([]byte, 100*1024)
-		rand.Read(content)
+		if _, err := rand.Read(content); err != nil {
+			b.Fatalf("failed to generate random data: %v", err)
+		}
 		os.WriteFile(filepath.Join(claudeDir, fmt.Sprintf("file-%d.txt", i)), content, 0644)
 	}
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unchecked return value of `rand.Read` in benchmarks can result in working with predictable (zeroed) data if generation fails.
🎯 **Impact:** Could lead to benchmark measurements of non-representative (empty) data processing, skewing results.
🔧 **Fix:** Added error checks to `rand.Read` calls to `b.Fatalf()` on failure.
✅ **Verification:** Verified by running tests, formatting, vetting, and code review. Added learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [12941957654949693557](https://jules.google.com/task/12941957654949693557) started by @coredipper*