### PR TITLE
⚡ Bolt: Use fixed worker pool for file hashing

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -596,7 +596,27 @@ func Status(cfg *config.Config) (*DiffResult, error) {
 	if numWorkers < 1 {
 		numWorkers = 1
 	}
-	sem := make(chan struct{}, numWorkers)
+
+	work := make(chan ScanResult, numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for f := range work {
+				data, err := os.ReadFile(f.AbsPath)
+				if err != nil {
+					continue
+				}
+				hash := ContentHash(data)
+
+				mu.Lock()
+				current.Files[f.RelPath] = FileEntry{
+					ContentHash: hash,
+				}
+				mu.Unlock()
+			}
+		}()
+	}
 
 	for _, f := range files {
 		// Fast path: if size and nanosecond mtime match manifest, assume
@@ -613,25 +633,9 @@ func Status(cfg *config.Config) (*DiffResult, error) {
 			}
 		}
 
-		wg.Add(1)
-		go func(f ScanResult) {
-			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-
-			data, err := os.ReadFile(f.AbsPath)
-			if err != nil {
-				return
-			}
-			hash := ContentHash(data)
-
-			mu.Lock()
-			current.Files[f.RelPath] = FileEntry{
-				ContentHash: hash,
-			}
-			mu.Unlock()
-		}(f)
+		work <- f
 	}
+	close(work)
 	wg.Wait()
 
 	diff := current.Diff(manifest)
@@ -683,7 +687,25 @@ func UnsealStatus(cfg *config.Config, opts ...UnsealOption) (*DiffResult, error)
 	if numWorkers < 1 {
 		numWorkers = 1
 	}
-	sem := make(chan struct{}, numWorkers)
+
+	work := make(chan ScanResult, numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for f := range work {
+				data, err := os.ReadFile(f.AbsPath)
+				if err != nil {
+					continue
+				}
+				hash := ContentHash(data)
+
+				mu.Lock()
+				onDisk[f.RelPath] = hash
+				mu.Unlock()
+			}
+		}()
+	}
 
 	for _, f := range files {
 		// Fast path: see Status above for the rationale and the
@@ -697,23 +719,9 @@ func UnsealStatus(cfg *config.Config, opts ...UnsealOption) (*DiffResult, error)
 			}
 		}
 
-		wg.Add(1)
-		go func(f ScanResult) {
-			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-
-			data, err := os.ReadFile(f.AbsPath)
-			if err != nil {
-				return
-			}
-			hash := ContentHash(data)
-
-			mu.Lock()
-			onDisk[f.RelPath] = hash
-			mu.Unlock()
-		}(f)
+		work <- f
 	}
+	close(work)
 	wg.Wait()
 
 	var result DiffResult


### PR DESCRIPTION
💡 **What:** Replaced the unbounded goroutine spawning in `store.Status` and `store.UnsealStatus` with a fixed worker pool pattern.
🎯 **Why:** The previous code spawned a new goroutine for every single file (potentially tens of thousands), relying on a semaphore channel inside the goroutine to limit concurrency. This still allocated a goroutine stack for every file, causing significant memory pressure and Go scheduler overhead.
📊 **Impact:** Reduces memory allocations dramatically and speeds up the slow path of file scanning by eliminating goroutine spawning and scheduling overhead.
🔬 **Measurement:** Verified via `go test -bench . ./internal/store/...` showing improved benchmark times and 0 regressions across the test suite.

---
*PR created automatically by Jules for task [16321017880679377855](https://jules.google.com/task/16321017880679377855) started by @coredipper*