### PR TITLE
🛡️ Sentinel: [LOW] Fix path traversal in object rotation (defense-in-depth)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,7 @@
 **Vulnerability:** Unchecked errors from `math/rand.Read` or `crypto/rand.Read` in benchmark tests.
 **Learning:** Unhandled random generation errors in benchmarks can lead to measuring the performance of predictable (zeroed) data generation or processing instead of actual random data processing, potentially skewing benchmark results or hiding actual errors.
 **Prevention:** Even in tests and benchmarks, always check the error returned by `rand.Read` and use `b.Fatalf` or `t.Fatalf` to abort the execution if it fails.
+## 2026-07-07 - Prevent Path Traversal in Rotate Object Paths
+**Vulnerability:** The `stagedObjectPath` function used in object rotation didn't validate if `hash` was a valid SHA-256 hex string before constructing paths, leading to path traversal vulnerability if a malicious manifest provides `../../etc/passwd` style `content_hash`.
+**Learning:** Functions that generate paths based on external inputs such as manifest contents, even in auxiliary workflows like migration or rotation, must always validate those inputs against the expected format.
+**Prevention:** In functions like `stagedObjectPath`, always apply the same validation `isValidHash` as used in the primary `ObjectStore` read/write paths, and return an error if validation fails.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1510,7 +1510,14 @@ func Rotate(cfg *config.Config, oldIdentity age.Identity, newRecipient age.Recip
 
 	applied := make([]string, 0, len(hashes))
 	for _, hash := range hashes {
-		data, err := os.ReadFile(stagedObjectPath(newRoot, hash))
+		path, err := stagedObjectPath(newRoot, hash)
+		if err != nil {
+			return len(applied), recoverRotationApplyFailure(
+				store, oldRoot, newRoot, hashes, applied,
+				fmt.Errorf("invalid hash for staged object: %w", err),
+			)
+		}
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return len(applied), recoverRotationApplyFailure(
 				store, oldRoot, newRoot, hashes, applied,
@@ -1607,12 +1614,18 @@ func uniqueManifestHashes(manifest *Manifest) []string {
 	return hashes
 }
 
-func stagedObjectPath(root, hash string) string {
-	return filepath.Join(root, hash[:2], hash[2:]+".age")
+func stagedObjectPath(root, hash string) (string, error) {
+	if !isValidHash(hash) {
+		return "", fmt.Errorf("invalid content hash: %q", hash)
+	}
+	return filepath.Join(root, hash[:2], hash[2:]+".age"), nil
 }
 
 func writeStagedObject(root, hash string, data []byte) error {
-	path := stagedObjectPath(root, hash)
+	path, err := stagedObjectPath(root, hash)
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return err
 	}
@@ -1622,7 +1635,12 @@ func writeStagedObject(root, hash string, data []byte) error {
 func rollbackRotatedObjects(store *ObjectStore, oldRoot string, hashes []string) error {
 	var errs []error
 	for _, hash := range hashes {
-		data, err := os.ReadFile(stagedObjectPath(oldRoot, hash))
+		path, err := stagedObjectPath(oldRoot, hash)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid hash for backup %s: %w", shortHash(hash), err))
+			continue
+		}
+		data, err := os.ReadFile(path)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("read backup %s: %w", shortHash(hash), err))
 			continue
@@ -1637,7 +1655,12 @@ func rollbackRotatedObjects(store *ObjectStore, oldRoot string, hashes []string)
 func rollForwardRotatedObjects(store *ObjectStore, newRoot string, hashes []string) error {
 	var errs []error
 	for _, hash := range hashes {
-		data, err := os.ReadFile(stagedObjectPath(newRoot, hash))
+		path, err := stagedObjectPath(newRoot, hash)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid hash for rotated %s: %w", shortHash(hash), err))
+			continue
+		}
+		data, err := os.ReadFile(path)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("read rotated %s: %w", shortHash(hash), err))
 			continue


### PR DESCRIPTION
🎯 **What:** Fixes a path traversal vulnerability in `stagedObjectPath` inside `internal/store/store.go`.
⚠️ **Risk:** A maliciously crafted manifest with an unexpected `content_hash` value (e.g., `../../etc/passwd`) could cause the object rotation process to traverse outside the `.rotate-*` staging directory, allowing arbitrary file read and write operations.
🛡️ **Solution:** `stagedObjectPath` now returns an error and explicitly validates the `hash` using `isValidHash(hash)` before joining it into a file path, matching the validation already used by the primary `ObjectStore`. All callers (`writeStagedObject`, `Rotate`, `rollbackRotatedObjects`, `rollForwardRotatedObjects`) were updated to correctly handle the new `error` return.
✅ **Verification:** Verified compilation and execution of `go test ./...`. All tests pass successfully. Added a Sentinel journal entry.

---
*PR created automatically by Jules for task [13921155360034104324](https://jules.google.com/task/13921155360034104324) started by @coredipper*